### PR TITLE
Basis for card identity deduction

### DIFF
--- a/HanabiGuru.Client.Console.Tests/CommandProcessingTestFramework.fs
+++ b/HanabiGuru.Client.Console.Tests/CommandProcessingTestFramework.fs
@@ -21,3 +21,7 @@ let processInput input =
     CommandInterface.processInput getInput (CommandInterface.pipeline commandExecuted fail fail)
 
     gameState
+
+let startGame names =
+    let addPlayers = names |> Set.toList |> List.map (sprintf "add player %s")
+    "start" :: addPlayers |> List.rev |> processInput

--- a/HanabiGuru.Client.Console.Tests/HanabiGuru.Client.Console.Tests.fsproj
+++ b/HanabiGuru.Client.Console.Tests/HanabiGuru.Client.Console.Tests.fsproj
@@ -65,6 +65,7 @@
     <Compile Include="CommandInterfaceIntegrationTests.fs" />
     <Compile Include="AddPlayersIntegrationTests.fs" />
     <Compile Include="StartGameIntegrationTests.fs" />
+    <Compile Include="InitialDeductionIntegrationTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsCheck">

--- a/HanabiGuru.Client.Console.Tests/InitialDeductionIntegrationTests.fs
+++ b/HanabiGuru.Client.Console.Tests/InitialDeductionIntegrationTests.fs
@@ -8,7 +8,8 @@ let ``After starting a game, players begin deducing the identities of their card
     let startedGame = CommandProcessingTestFramework.startGame names
     GameState.players startedGame
     |> Set.toList
-    |> List.map (fun player -> GameState.playerView player startedGame)
-    |> List.map (fun view -> (PlayerView.hand view, view))
-    |> List.map (fun (cards, view) -> List.map (PlayerView.CardIdentity.deduce view) cards)
+    |> List.map (fun player ->
+        let view = GameState.playerView player startedGame
+        PlayerView.hand view
+        |> List.map (PlayerView.CardIdentity.deduce view))
     |> List.forall (not << List.isEmpty)

--- a/HanabiGuru.Client.Console.Tests/InitialDeductionIntegrationTests.fs
+++ b/HanabiGuru.Client.Console.Tests/InitialDeductionIntegrationTests.fs
@@ -9,7 +9,6 @@ let ``After starting a game, players begin deducing the identities of their card
     GameState.players startedGame
     |> Set.toList
     |> List.map (fun player -> GameState.playerView player startedGame)
-    |> List.map PlayerView.hand
-    |> List.collect id
-    |> List.map (fun (ConcealedCard candidateIdentities) -> candidateIdentities)
+    |> List.map (fun view -> (PlayerView.hand view, view))
+    |> List.map (fun (cards, view) -> List.map (PlayerView.CardIdentity.deduce view) cards)
     |> List.forall (not << List.isEmpty)

--- a/HanabiGuru.Client.Console.Tests/InitialDeductionIntegrationTests.fs
+++ b/HanabiGuru.Client.Console.Tests/InitialDeductionIntegrationTests.fs
@@ -1,0 +1,15 @@
+﻿module HanabiGuru.Client.Console.Tests.InitialDeductionIntegrationTests
+
+open FsCheck.Xunit
+open HanabiGuru.Engine
+
+[<Property(Arbitrary = [| typeof<InputGeneration> |])>]
+let ``After starting a game, players begin deducing the identities of their cards`` (Names names) =
+    let startedGame = CommandProcessingTestFramework.startGame names
+    GameState.players startedGame
+    |> Set.toList
+    |> List.map (fun player -> GameState.playerView player startedGame)
+    |> List.map PlayerView.hand
+    |> List.collect id
+    |> List.map (fun (ConcealedCard candidateIdentities) -> candidateIdentities)
+    |> List.forall (not << List.isEmpty)

--- a/HanabiGuru.Client.Console.Tests/InputGeneration.fs
+++ b/HanabiGuru.Client.Console.Tests/InputGeneration.fs
@@ -12,7 +12,8 @@ type InputGeneration =
         Arb.generate<char>
         |> Gen.filter (fun c -> ' ' <= c && c <= '~')
         |> Gen.nonEmptyListOf
-        |> Gen.map string
+        |> Gen.map String.Concat
+        |> Gen.map (fun s -> s.Trim())
         |> Gen.filter (not << String.IsNullOrWhiteSpace)
 
     static member Name() =

--- a/HanabiGuru.Engine.Tests/DeductionTests.fs
+++ b/HanabiGuru.Engine.Tests/DeductionTests.fs
@@ -9,35 +9,42 @@ let ``There is always at least one candidate identity for all cards`` (GameReady
     let players = GameState.players game |> Set.toList
 
     Game.startGame game
-    |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
-    |> Result.map (List.map (fun view -> (PlayerView.hand view, view)))
-    |> Result.map (List.collect (fun (cards, view) -> List.map (PlayerView.CardIdentity.deduce view) cards))
-    |> Result.map (List.filter List.isEmpty) =! Ok []
+    |> Result.map (fun game ->
+        players
+        |> List.collect (fun player ->
+            let view = GameState.playerView player game
+            PlayerView.hand view
+            |> List.map (PlayerView.CardIdentity.deduce view))
+        |> List.filter List.isEmpty) =! Ok []
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``All candidate identities always have a probability above zero and no greater than one`` (GameReadyToStart game) =
     let players = GameState.players game |> Set.toList
 
     Game.startGame game
-    |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
-    |> Result.map (List.map (fun view -> (PlayerView.hand view, view)))
-    |> Result.map (List.collect (fun (cards, view) -> List.map (PlayerView.CardIdentity.deduce view) cards))
-    |> Result.map (List.collect id)
-    |> Result.map (List.filter (fun candidate -> candidate.probability <= 0.0 || candidate.probability > 1.0)) =! Ok []
+    |> Result.map (fun game ->
+        players
+        |> List.collect (fun player ->
+            let view = GameState.playerView player game
+            PlayerView.hand view
+            |> List.map (PlayerView.CardIdentity.deduce view))
+        |> List.collect id
+        |> List.filter (fun candidate -> candidate.probability <= 0.0 || candidate.probability > 1.0)) =! Ok []
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``The sum of probabilities for all candidates for each card is one`` (GameReadyToStart game) =
     let players = GameState.players game |> Set.toList
 
     test <@ Game.startGame game
-        |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
-        |> Result.map (List.map (fun view -> (PlayerView.hand view, view)))
-        |> Result.map (List.map (fun (cards, view) -> List.map (PlayerView.CardIdentity.deduce view) cards))
-        |> Result.map (List.map (List.map (List.sumBy (fun candidate -> candidate.probability))))
-        |> Result.map (List.collect id)
-        |> Result.map (List.map ((-) 1.0))
-        |> Result.map (List.map abs)
-        |> Result.map (List.forall ((>) 1e-10)) = Ok true
+        |> Result.map (fun game ->
+            players
+            |> List.collect (fun player ->
+                let view = GameState.playerView player game
+                PlayerView.hand view
+                |> List.map (PlayerView.CardIdentity.deduce view
+                    >> List.sumBy (fun candidate -> candidate.probability)))
+            |> List.map ((-) 1.0 >> abs)
+            |> List.forall ((>) 1e-10)) = Ok true
     @>
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
@@ -63,8 +70,9 @@ let ``Candidate identities include all identities for which at least one card re
             let view = GameState.playerView player game
             view
             |> PlayerView.hand
-            |> List.map (fun card -> PlayerView.CardIdentity.deduce view card)
-            |> List.map (List.map (fun candidate -> candidate.card) >> set))) =! unrevealedCards
+            |> List.map (PlayerView.CardIdentity.deduce view
+                >> List.map (fun candidate -> candidate.card)
+                >> set))) =! unrevealedCards
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``The probabilities of candidate identities are relative to the number of unrevealed instances``
@@ -77,12 +85,12 @@ let ``The probabilities of candidate identities are relative to the number of un
         |> Result.map (fun startedGame ->
             GameState.hands startedGame
             |> List.map (fun hand ->
-                    hand.cards
-                    |> List.append (GameState.drawDeck startedGame)
-                    |> List.replicate (List.length hand.cards)
-                    |> List.map (List.countBy id)
-                    |> List.map (List.sortByDescending (fun (card, count) -> (count, card)))
-                    |> List.map (List.map fst)))
+                hand.cards
+                |> List.append (GameState.drawDeck startedGame)
+                |> List.replicate (List.length hand.cards)
+                |> List.map (List.countBy id
+                    >> List.sortByDescending (fun (card, count) -> (count, card))
+                    >> List.map fst)))
 
     startedGameOrError
     |> Result.map (fun game ->
@@ -91,17 +99,19 @@ let ``The probabilities of candidate identities are relative to the number of un
             let view = GameState.playerView player game
             view
             |> PlayerView.hand
-            |> List.map (fun card -> PlayerView.CardIdentity.deduce view card)
-            |> List.map (List.sortByDescending (fun candidate -> (candidate.probability, candidate.card)))
-            |> List.map (List.map (fun candidate -> candidate.card)))) =! unrevealedCards
+            |> List.map (PlayerView.CardIdentity.deduce view
+                >> List.sortByDescending (fun candidate -> (candidate.probability, candidate.card))
+                >> List.map (fun candidate -> candidate.card)))) =! unrevealedCards
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Candidate identities are returned in reverse order of probability`` (GameReadyToStart game) =
+let ``Candidate identities are returned in descending order of probability`` (GameReadyToStart game) =
     let players = GameState.players game |> Set.toList
     let candidateProbabilities =
         Game.startGame game
-        |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
-        |> Result.map (List.map (fun view -> (PlayerView.hand view, view)))
-        |> Result.map (List.collect (fun (cards, view) -> List.map (PlayerView.CardIdentity.deduce view) cards))
-        |> Result.map (List.map (List.map (fun candidate -> candidate.probability)))
+        |> Result.map (fun game ->
+            players
+            |> List.collect (fun player ->
+                let view = GameState.playerView player game
+                PlayerView.hand view
+                |> List.map (PlayerView.CardIdentity.deduce view >> List.map (fun candidate -> candidate.probability))))
     candidateProbabilities =! (candidateProbabilities |> Result.map (List.map (List.sortDescending)))

--- a/HanabiGuru.Engine.Tests/DeductionTests.fs
+++ b/HanabiGuru.Engine.Tests/DeductionTests.fs
@@ -1,0 +1,107 @@
+﻿module HanabiGuru.Engine.Tests.DeductionTests
+
+open FsCheck.Xunit
+open Swensen.Unquote
+open HanabiGuru.Engine
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``There is always at least one candidate identity for all cards`` (GameReadyToStart game) =
+    let players = GameState.players game |> Set.toList
+
+    Game.startGame game
+    |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
+    |> Result.map (List.map (fun view -> (PlayerView.hand view, view)))
+    |> Result.map (List.collect (fun (cards, view) -> List.map (PlayerView.CardIdentity.deduce view) cards))
+    |> Result.map (List.filter List.isEmpty) =! Ok []
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``All candidate identities always have a probability above zero and no greater than one`` (GameReadyToStart game) =
+    let players = GameState.players game |> Set.toList
+
+    Game.startGame game
+    |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
+    |> Result.map (List.map (fun view -> (PlayerView.hand view, view)))
+    |> Result.map (List.collect (fun (cards, view) -> List.map (PlayerView.CardIdentity.deduce view) cards))
+    |> Result.map (List.collect id)
+    |> Result.map (List.filter (fun candidate -> candidate.probability <= 0.0 || candidate.probability > 1.0)) =! Ok []
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``The sum of probabilities for all candidates for each card is one`` (GameReadyToStart game) =
+    let players = GameState.players game |> Set.toList
+
+    test <@ Game.startGame game
+        |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
+        |> Result.map (List.map (fun view -> (PlayerView.hand view, view)))
+        |> Result.map (List.map (fun (cards, view) -> List.map (PlayerView.CardIdentity.deduce view) cards))
+        |> Result.map (List.map (List.map (List.sumBy (fun candidate -> candidate.probability))))
+        |> Result.map (List.collect id)
+        |> Result.map (List.map ((-) 1.0))
+        |> Result.map (List.map abs)
+        |> Result.map (List.forall ((>) 1e-10)) = Ok true
+    @>
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Candidate identities include all identities for which at least one card remains unrevealed``
+    (GameReadyToStart game) =
+
+    let startedGameOrError = Game.startGame game
+    let players = GameState.players game |> Set.toList
+    let unrevealedCards =
+        startedGameOrError
+        |> Result.map (fun startedGame ->
+            GameState.hands startedGame
+            |> List.map (fun hand ->
+                    hand.cards
+                    |> List.append (GameState.drawDeck startedGame)
+                    |> List.replicate (List.length hand.cards)
+                    |> List.map set))
+
+    startedGameOrError
+    |> Result.map (fun game ->
+        players
+        |> List.map (fun player ->
+            let view = GameState.playerView player game
+            view
+            |> PlayerView.hand
+            |> List.map (fun card -> PlayerView.CardIdentity.deduce view card)
+            |> List.map (List.map (fun candidate -> candidate.card) >> set))) =! unrevealedCards
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``The probabilities of candidate identities are relative to the number of unrevealed instances``
+    (GameReadyToStart game) =
+
+    let startedGameOrError = Game.startGame game
+    let players = GameState.players game |> Set.toList
+    let unrevealedCards =
+        startedGameOrError
+        |> Result.map (fun startedGame ->
+            GameState.hands startedGame
+            |> List.map (fun hand ->
+                    hand.cards
+                    |> List.append (GameState.drawDeck startedGame)
+                    |> List.replicate (List.length hand.cards)
+                    |> List.map (List.countBy id)
+                    |> List.map (List.sortByDescending (fun (card, count) -> (count, card)))
+                    |> List.map (List.map fst)))
+
+    startedGameOrError
+    |> Result.map (fun game ->
+        players
+        |> List.map (fun player ->
+            let view = GameState.playerView player game
+            view
+            |> PlayerView.hand
+            |> List.map (fun card -> PlayerView.CardIdentity.deduce view card)
+            |> List.map (List.sortByDescending (fun candidate -> (candidate.probability, candidate.card)))
+            |> List.map (List.map (fun candidate -> candidate.card)))) =! unrevealedCards
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Candidate identities are returned in reverse order of probability`` (GameReadyToStart game) =
+    let players = GameState.players game |> Set.toList
+    let candidateProbabilities =
+        Game.startGame game
+        |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
+        |> Result.map (List.map (fun view -> (PlayerView.hand view, view)))
+        |> Result.map (List.collect (fun (cards, view) -> List.map (PlayerView.CardIdentity.deduce view) cards))
+        |> Result.map (List.map (List.map (fun candidate -> candidate.probability)))
+    candidateProbabilities =! (candidateProbabilities |> Result.map (List.map (List.sortDescending)))

--- a/HanabiGuru.Engine.Tests/HanabiGuru.Engine.Tests.fsproj
+++ b/HanabiGuru.Engine.Tests/HanabiGuru.Engine.Tests.fsproj
@@ -65,6 +65,7 @@
     <Compile Include="EventHistoryTests.fs" />
     <Compile Include="AddPlayersTests.fs" />
     <Compile Include="StartGameTests.fs" />
+    <Compile Include="DeductionTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsCheck">

--- a/HanabiGuru.Engine.Tests/StartGameTests.fs
+++ b/HanabiGuru.Engine.Tests/StartGameTests.fs
@@ -129,6 +129,19 @@ let ``Starting the game deals the initial hands non-deterministically`` (GameRea
     |> List.length >! 1
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Each player has the same number of cards in their hands`` (GameReadyToStart game) =
+    let players = GameState.players game |> Set.toList
+    let handSizes view =
+        (PlayerView.hand view |> List.length)
+        :: (PlayerView.otherHands view |> List.map (fun hand -> hand.cards) |> List.map List.length)
+
+    test <@ Game.startGame game
+    |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
+    |> Result.map (List.collect handSizes)
+    |> Result.map List.distinct
+    |> Result.map List.length = Ok 1 @>
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Players see the cards in the hands of the other players`` (GameReadyToStart game) =
     let players = GameState.players game |> Set.toList
     let startedGame = Game.startGame game

--- a/HanabiGuru.Engine/Card.fs
+++ b/HanabiGuru.Engine/Card.fs
@@ -11,3 +11,6 @@ type Rank = Rank of int
 
 type Card =
     | Card of Suit * Rank
+
+type ConcealedCard =
+    | ConcealedCard of bool list

--- a/HanabiGuru.Engine/Card.fs
+++ b/HanabiGuru.Engine/Card.fs
@@ -9,8 +9,12 @@ type Suit =
 
 type Rank = Rank of int
 
-type Card =
-    | Card of Suit * Rank
+type Card = Card of Suit * Rank
 
-type ConcealedCard =
-    | ConcealedCard of bool list
+type ConcealedCard = ConcealedCard
+
+type CandidateIdentity =
+    {
+        card : Card
+        probability : double
+    }

--- a/HanabiGuru.Engine/GameEvent.fs
+++ b/HanabiGuru.Engine/GameEvent.fs
@@ -19,8 +19,8 @@ module GameEvent =
             PlayerEvent.FuseTokenAdded |> Some
         | ClockTokenAdded ->
             PlayerEvent.ClockTokenAdded |> Some
-        | CardAddedToDrawDeck _ ->
-            PlayerEvent.CardAddedToDrawDeck |> Some
+        | CardAddedToDrawDeck card ->
+            PlayerEvent.CardAddedToDrawDeck card |> Some
         | CardDealtToPlayer (card, otherPlayer) when otherPlayer <> player ->
             CardDealtToOtherPlayer (card, otherPlayer) |> Some
         | CardDealtToPlayer _ ->

--- a/HanabiGuru.Engine/PlayerEvent.fs
+++ b/HanabiGuru.Engine/PlayerEvent.fs
@@ -5,6 +5,6 @@ type PlayerEvent =
     | OtherPlayerJoined of PlayerIdentity
     | FuseTokenAdded
     | ClockTokenAdded
-    | CardAddedToDrawDeck
+    | CardAddedToDrawDeck of Card
     | CardDealtToSelf
     | CardDealtToOtherPlayer of Card * PlayerIdentity

--- a/HanabiGuru.Engine/PlayerView.fs
+++ b/HanabiGuru.Engine/PlayerView.fs
@@ -20,6 +20,8 @@ let drawDeckSize = List.sumBy (function
     | CardDealtToOtherPlayer _ -> -1
     | _ -> 0)
 
+let hand _ = [ConcealedCard [true]]
+
 let otherHands view =
     view
     |> List.choose (function


### PR DESCRIPTION
After starting a new game, each player can begin to deduce some information about the identities of the cards in their own hand, by eliminating the cards which have been revealed to him, in the hands of the other players.