### PR TITLE
Information giving

### DIFF
--- a/HanabiGuru.Client.Console.Tests/AddPlayersIntegrationTests.fs
+++ b/HanabiGuru.Client.Console.Tests/AddPlayersIntegrationTests.fs
@@ -7,7 +7,7 @@ open HanabiGuru.Engine
 open HanabiGuru.Client.Console
 
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
-let ``Players can be added to game`` (Names names) =
+let ``Players can be added to game`` (ValidNames names) =
     names
     |> Set.toList
     |> List.map (sprintf "add player %s")

--- a/HanabiGuru.Client.Console.Tests/AddPlayersIntegrationTests.fs
+++ b/HanabiGuru.Client.Console.Tests/AddPlayersIntegrationTests.fs
@@ -8,11 +8,12 @@ open HanabiGuru.Client.Console
 
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
 let ``Players can be added to game`` (ValidNames names) =
+    let names = Set.toList names
     names
-    |> Set.toList
     |> List.map (sprintf "add player %s")
     |> CommandProcessingTestFramework.processInput
-    |> GameState.players =! Set.map PlayerIdentity.create names
+    |> GameState.players
+    |> List.sort =! (names |> List.map PlayerIdentity.create |> List.sort)
 
 [<Property>]
 let ``Adding the same player to the game repeatedly returns errors`` (name : string) (PositiveInt repetitions) =

--- a/HanabiGuru.Client.Console.Tests/CommandInterfaceTests.fs
+++ b/HanabiGuru.Client.Console.Tests/CommandInterfaceTests.fs
@@ -4,6 +4,7 @@ open Xunit
 open FsCheck.Xunit
 open Swensen.Unquote
 open HanabiGuru.Client.Console
+open HanabiGuru.Engine
 
 [<Property>]
 let ``Input processing processes input received and then terminates`` (input : string list) =
@@ -33,10 +34,10 @@ let private errorMessage = function
 
 [<Fact>]
 let ``Unrecognised input is rejected`` () =
-    test <@ "unrecognised" |> CommandInterface.parse |> errorMessage |> contains "Expecting: command" @>
+    test <@ "unrecognised" |> CommandInterface.parse |> errorMessage |> contains "Expecting:" @>
 
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
-let ``Add player input can be parsed into command`` (Name name) =
+let ``Add player input is parsed into command`` (ValidName name) =
     name |> sprintf "add player %s" |> CommandInterface.parse =! (AddPlayer name |> Ok)
 
 [<Fact>]
@@ -47,3 +48,32 @@ let ``Add player input with no name is rejected`` () =
 [<Fact>]
 let ``Start game input is parsed into command`` () =
     "start" |> CommandInterface.parse =! Ok StartGame
+
+let traitString = function
+    | SuitTrait suit -> sprintf "%A" suit
+    | RankTrait (Rank rank) -> sprintf "%A" rank
+
+[<Property(Arbitrary = [| typeof<InputGeneration> |])>]
+let ``Give information input is parsed into command`` (ValidName name) (cardTrait : CardTrait) =
+    sprintf "tell %s %s" (traitString cardTrait) name
+    |> CommandInterface.parse =! Ok (GiveInformation (name, cardTrait))
+
+[<Fact>]
+let ``Give information input with no details is rejected`` () =
+    test <@ "tell" |> CommandInterface.parse |> errorMessage |> contains "Expecting: colour or number" @>
+    test <@ "tell " |> CommandInterface.parse |> errorMessage |> contains "Expecting: colour or number" @>
+
+[<Fact>]
+let ``Give information input with invalid colour or number is rejected`` () =
+    test <@ "tell invalid" |> CommandInterface.parse |> errorMessage |> contains "Expecting: colour or number" @>
+
+[<Property>]
+let ``Give information input with no name is rejected`` (cardTrait : CardTrait) =
+    test <@ sprintf "tell %s" (traitString cardTrait)
+        |> CommandInterface.parse
+        |> errorMessage
+        |> contains "Expecting: player name" @>
+    test <@ sprintf "tell %s " (traitString cardTrait)
+        |> CommandInterface.parse
+        |> errorMessage
+        |> contains "Expecting: player name" @>

--- a/HanabiGuru.Client.Console.Tests/InitialDeductionIntegrationTests.fs
+++ b/HanabiGuru.Client.Console.Tests/InitialDeductionIntegrationTests.fs
@@ -4,7 +4,7 @@ open FsCheck.Xunit
 open HanabiGuru.Engine
 
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
-let ``After starting a game, players begin deducing the identities of their cards`` (Names names) =
+let ``After starting a game, players begin deducing the identities of their cards`` (ValidNames names) =
     let startedGame = CommandProcessingTestFramework.startGame names
     GameState.players startedGame
     |> Set.toList

--- a/HanabiGuru.Client.Console.Tests/InitialDeductionIntegrationTests.fs
+++ b/HanabiGuru.Client.Console.Tests/InitialDeductionIntegrationTests.fs
@@ -7,7 +7,6 @@ open HanabiGuru.Engine
 let ``After starting a game, players begin deducing the identities of their cards`` (ValidNames names) =
     let startedGame = CommandProcessingTestFramework.startGame names
     GameState.players startedGame
-    |> Set.toList
     |> List.map (fun player ->
         let view = GameState.playerView player startedGame
         PlayerView.hand view

--- a/HanabiGuru.Client.Console.Tests/InputGeneration.fs
+++ b/HanabiGuru.Client.Console.Tests/InputGeneration.fs
@@ -4,8 +4,8 @@ open System
 open FsCheck
 open HanabiGuru.Engine
 
-type Name = Name of string
-type Names = Names of Set<string>
+type ValidName = ValidName of string
+type ValidNames = ValidNames of Set<string>
 
 type InputGeneration =
     static member private nameGenerator =
@@ -16,16 +16,16 @@ type InputGeneration =
         |> Gen.map (fun s -> s.Trim())
         |> Gen.filter (not << String.IsNullOrWhiteSpace)
 
-    static member Name() =
+    static member ValidName() =
         InputGeneration.nameGenerator
-        |> Gen.map Name
+        |> Gen.map ValidName
         |> Arb.fromGen
 
-    static member Names() =
+    static member ValidNames() =
         InputGeneration.nameGenerator
         |> Gen.nonEmptyListOf
         |> Gen.map set
         |> Gen.filter (Set.count >> ((<=) GameRules.minimumPlayers)) 
         |> Gen.filter (Set.count >> ((>=) GameRules.maximumPlayers)) 
-        |> Gen.map Names
+        |> Gen.map ValidNames
         |> Arb.fromGen

--- a/HanabiGuru.Client.Console.Tests/StartGameIntegrationTests.fs
+++ b/HanabiGuru.Client.Console.Tests/StartGameIntegrationTests.fs
@@ -7,11 +7,11 @@ open HanabiGuru.Engine
 let private hasEmptyHand player = List.isEmpty player.cards
 
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
-let ``Starting a game deals cards to all players`` (Names names) =
+let ``Starting a game deals cards to all players`` (ValidNames names) =
     CommandProcessingTestFramework.startGame names |> GameState.hands |> List.filter hasEmptyHand =! []
 
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
-let ``After starting a game, each player has a hand of concealed cards`` (Names names) =
+let ``After starting a game, each player has a hand of concealed cards`` (ValidNames names) =
     let startedGame = CommandProcessingTestFramework.startGame names
     GameState.players startedGame
     |> Set.toList
@@ -20,7 +20,7 @@ let ``After starting a game, each player has a hand of concealed cards`` (Names 
     |> List.forall (not << List.isEmpty)
 
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
-let ``After starting a game, all players see cards in the hands of all other players`` (Names names) =
+let ``After starting a game, all players see cards in the hands of all other players`` (ValidNames names) =
     let startedGame = CommandProcessingTestFramework.startGame names
     let players = GameState.players startedGame
     let playerViews = players |> Set.toList |> List.map (fun player -> GameState.playerView player startedGame)
@@ -28,9 +28,9 @@ let ``After starting a game, all players see cards in the hands of all other pla
     otherHands |> List.collect id |> List.filter hasEmptyHand =! []
 
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
-let ``Starting a game adds fuse tokens`` (Names names) =
+let ``Starting a game adds fuse tokens`` (ValidNames names) =
     CommandProcessingTestFramework.startGame names |> GameState.fuseTokens >! 0
 
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
-let ``Starting a game adds clock tokens`` (Names names) =
+let ``Starting a game adds clock tokens`` (ValidNames names) =
     CommandProcessingTestFramework.startGame names |> GameState.clockTokens >! 0

--- a/HanabiGuru.Client.Console.Tests/StartGameIntegrationTests.fs
+++ b/HanabiGuru.Client.Console.Tests/StartGameIntegrationTests.fs
@@ -14,7 +14,6 @@ let ``Starting a game deals cards to all players`` (ValidNames names) =
 let ``After starting a game, each player has a hand of concealed cards`` (ValidNames names) =
     let startedGame = CommandProcessingTestFramework.startGame names
     GameState.players startedGame
-    |> Set.toList
     |> List.map (fun player -> GameState.playerView player startedGame)
     |> List.map PlayerView.hand
     |> List.forall (not << List.isEmpty)
@@ -23,7 +22,6 @@ let ``After starting a game, each player has a hand of concealed cards`` (ValidN
 let ``After starting a game, all players see cards in the hands of all other players`` (ValidNames names) =
     let startedGame = CommandProcessingTestFramework.startGame names
     GameState.players startedGame
-    |> Set.toList
     |> List.map (fun player -> GameState.playerView player startedGame)
     |> List.map (fun view ->
         PlayerView.otherPlayers view

--- a/HanabiGuru.Client.Console.Tests/StartGameIntegrationTests.fs
+++ b/HanabiGuru.Client.Console.Tests/StartGameIntegrationTests.fs
@@ -22,10 +22,14 @@ let ``After starting a game, each player has a hand of concealed cards`` (ValidN
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
 let ``After starting a game, all players see cards in the hands of all other players`` (ValidNames names) =
     let startedGame = CommandProcessingTestFramework.startGame names
-    let players = GameState.players startedGame
-    let playerViews = players |> Set.toList |> List.map (fun player -> GameState.playerView player startedGame)
-    let otherHands = List.map PlayerView.otherHands playerViews
-    otherHands |> List.collect id |> List.filter hasEmptyHand =! []
+    GameState.players startedGame
+    |> Set.toList
+    |> List.map (fun player -> GameState.playerView player startedGame)
+    |> List.map (fun view ->
+        PlayerView.otherPlayers view
+        |> List.map (fun otherPlayer -> PlayerView.otherHand otherPlayer view))
+    |> List.collect id
+    |> List.filter hasEmptyHand =! []
 
 [<Property(Arbitrary = [| typeof<InputGeneration> |])>]
 let ``Starting a game adds fuse tokens`` (ValidNames names) =

--- a/HanabiGuru.Client.Console/Command.fs
+++ b/HanabiGuru.Client.Console/Command.fs
@@ -1,8 +1,11 @@
 ﻿namespace HanabiGuru.Client.Console
 
+open HanabiGuru.Engine
+
 type Command =
     | AddPlayer of string
     | StartGame
+    | GiveInformation of string * CardTrait
 
 module Command =
     open HanabiGuru.Engine
@@ -10,3 +13,4 @@ module Command =
     let execute history = function
         | AddPlayer name -> Game.addPlayer (PlayerIdentity.create name) history
         | StartGame -> Game.startGame history
+        | GiveInformation (name, cardTrait) -> Game.giveInformation (PlayerIdentity.create name) cardTrait history

--- a/HanabiGuru.Client.Console/CommandInterface.fs
+++ b/HanabiGuru.Client.Console/CommandInterface.fs
@@ -16,12 +16,22 @@ let processInput getInput pipeline =
     subscriptions |> List.iter (fun (subscription : IDisposable) -> subscription.Dispose())
 
 let parse input =
+    let name = many1Chars anyChar <?> "player name"
     let addPlayer =
-        let prefix = skipString "add" >>. spaces >>. skipString "player" >>. spaces <?> "command"
-        let name = many1Chars anyChar |>> AddPlayer <?> "player name"
-        prefix >>. name
+        let prefix = skipString "add" >>. spaces >>. skipString "player" <?> "add player"
+        prefix >>. spaces >>. name |>> AddPlayer
     let startGame = stringReturn "start" StartGame
-    let parser = choice [addPlayer; startGame]
+    let giveInformation =
+        let suitTrait = 
+            [Blue; Green; Red; White; Yellow]
+            |> List.map (fun suit -> stringReturn (sprintf "%A" suit) (SuitTrait suit))
+            |> choice
+            <?> "colour"
+        let rankTrait = pint32 |>> (Rank >> RankTrait) <?> "number"
+        let cardTrait = suitTrait <|> rankTrait
+        skipString "tell" >>. spaces >>. cardTrait .>> spaces .>>. name
+            |>> (fun (cardTrait, name) -> GiveInformation (name, cardTrait))
+    let parser = spaces >>. choice [addPlayer; startGame; giveInformation]
     match run parser input with
     | Success (command, _, _) -> command |> Result.Ok
     | Failure (errorMessage, _, _) -> Result.Error (sprintf "%A" errorMessage)

--- a/HanabiGuru.Client.Console/CommandInterface.fs
+++ b/HanabiGuru.Client.Console/CommandInterface.fs
@@ -7,6 +7,7 @@ open HanabiGuru.Engine
 let processInput getInput pipeline =
     let events = new Event<_> ()
     let rec getNextInput () =
+        printf "> "
         getInput ()
         |> Option.iter (fun input ->
             events.Trigger input
@@ -36,29 +37,25 @@ let parse input =
     | Success (command, _, _) -> command |> Result.Ok
     | Failure (errorMessage, _, _) -> Result.Error (sprintf "%A" errorMessage)
 
-let pipeline gameUpdated commandFailed inputInvalid inputStream =
-    let separateErrors = function
-        | Result.Ok result -> Choice1Of2 result
-        | Result.Error error -> Choice2Of2 error
-    let inputParsingPipeline = Observable.map parse
-    let commandExecutionPipeline = 
-        Observable.scan (fun (_, history) command ->
-            match Command.execute history command with
-            | Result.Ok newHistory -> Result.Ok newHistory |> Some, newHistory
-            | Result.Error reasons -> Result.Error reasons |> Some, history)
-            (None, EventHistory.empty)
-        >> Observable.choose fst
+type private InputArtifact =
+    | NewGame of EventHistory
+    | CommandFailure of CannotPerformAction
+    | InvalidCommand of string
 
+let pipeline gameUpdated commandFailed inputInvalid inputStream =
     inputStream
-    |> inputParsingPipeline
-    |> Observable.split separateErrors
-    |> fun (commands, invalidInput) ->
-        commands
-        |> commandExecutionPipeline
-        |> Observable.split separateErrors
-        |> fun (events, failedCommands) ->
-            [
-                events |> Observable.subscribe gameUpdated
-                failedCommands |> Observable.subscribe commandFailed
-                invalidInput |> Observable.subscribe inputInvalid
-            ]
+    |> Observable.scan
+        (fun (_, currentGameState) input ->
+            input
+            |> (parse >> Result.mapError InvalidCommand)
+            |> Result.bind (Command.execute currentGameState >> Result.mapError CommandFailure)
+            |> function
+                | Result.Error errorArtifact -> (errorArtifact, currentGameState)
+                | Result.Ok newGameState -> (NewGame newGameState, newGameState))
+        (NewGame EventHistory.empty, EventHistory.empty)
+    |> Observable.map fst
+    |> Observable.subscribe (function
+        | NewGame gameState -> gameUpdated gameState
+        | CommandFailure reasons -> commandFailed reasons
+        | InvalidCommand parseError -> inputInvalid parseError)
+    |> List.singleton

--- a/HanabiGuru.Client.Console/Presentation.fs
+++ b/HanabiGuru.Client.Console/Presentation.fs
@@ -48,7 +48,7 @@ let private playersTasks players =
     let playerTask (Name name) = name |> task printStringData
     task printStaticLabel "Players"
     :: task printStructure ": "
-    :: (players |> Set.toList |> List.map playerTask |> List.weave (task printStructure ", "))
+    :: (players |> List.map playerTask |> List.weave (task printStructure ", "))
 
 let private cardTask backgroundColour (Card (suit, Rank rank)) =
     task (taskWithConsoleColours backgroundColour (cardColour suit) (printf "%i")) rank

--- a/HanabiGuru.Client.Console/Presentation.fs
+++ b/HanabiGuru.Client.Console/Presentation.fs
@@ -53,7 +53,7 @@ let private playersTasks players =
 let private cardTask backgroundColour (Card (suit, Rank rank)) =
     task (taskWithConsoleColours backgroundColour (cardColour suit) (printf "%i")) rank
 
-let private otherHandsTasks =
+let private otherHandsTasks view =
     let nameTask (name : string) =
         let nameWidth = 10
         let printName = printLabel <| printf "%*s" nameWidth
@@ -65,10 +65,12 @@ let private otherHandsTasks =
             (task printStructure " ")
             (List.map (fun { identity = card } -> cardTask cardBackground card) hand)
 
-    PlayerView.otherHands
-    >> List.map handTasks
-    >> List.map (List.reduce (>>))
-    >> List.weave lineBreakTask
+    view
+    |> PlayerView.otherPlayers
+    |> List.map (fun otherPlayer -> PlayerView.otherHand otherPlayer view)
+    |> List.map handTasks
+    |> List.map (List.reduce (>>))
+    |> List.weave lineBreakTask
 
 let private candidateIdentityTask { card = card; probability = p } =
     let probabilityTask = 

--- a/HanabiGuru.Client.Console/Presentation.fs
+++ b/HanabiGuru.Client.Console/Presentation.fs
@@ -61,7 +61,9 @@ let private otherHandsTasks =
     let handTasks { player = Name name; cards = hand } =
         nameTask name
         :: task printStructure ": "
-        :: List.weave (task printStructure " ") (List.map (cardTask cardBackground) hand)
+        :: List.weave
+            (task printStructure " ")
+            (List.map (fun { identity = card } -> cardTask cardBackground card) hand)
 
     PlayerView.otherHands
     >> List.map handTasks

--- a/HanabiGuru.Client.Console/Presentation.fs
+++ b/HanabiGuru.Client.Console/Presentation.fs
@@ -85,7 +85,7 @@ let private candidateIdentityTask { card = card; probability = p } =
 let private ownCardTask candidateIdentities =
     candidateIdentities
     |> List.map candidateIdentityTask
-    |> List.take 5
+    |> List.truncate 5
     |> List.weave (task printStructure " ")
     |> List.reduce (>>)
 

--- a/HanabiGuru.Client.Console/Presentation.fs
+++ b/HanabiGuru.Client.Console/Presentation.fs
@@ -144,7 +144,8 @@ let commandFailure failure =
                 | GameAlreadyStarted -> "the game has already started"))
         | CannotGiveInformation reasons ->
             ("Cannot give information", reasons |> List.map (function
-                | NoMatchingCards -> "at least one card must match the information given"))
+                | NoMatchingCards -> "at least one card must match the information given"
+                | InvalidRecipient -> "the recipient must be one of the other players in the game"))
     let summary, reasons = (display failure)
     message summary reasons |> printfn "%s"
 

--- a/HanabiGuru.Client.Console/Presentation.fs
+++ b/HanabiGuru.Client.Console/Presentation.fs
@@ -142,6 +142,9 @@ let commandFailure failure =
                 | WaitingForMinimumPlayers ->
                     sprintf "waiting for the minimum number of players (%i)" GameRules.minimumPlayers
                 | GameAlreadyStarted -> "the game has already started"))
+        | CannotTakeTurn reasons ->
+            ("Cannot take turn", reasons |> List.map (function
+                | GameNotStarted -> "the game has not started"))
         | CannotGiveInformation reasons ->
             ("Cannot give information", reasons |> List.map (function
                 | NoClockTokensAvailable -> "no clock tokens are available"

--- a/HanabiGuru.Client.Console/Presentation.fs
+++ b/HanabiGuru.Client.Console/Presentation.fs
@@ -144,6 +144,7 @@ let commandFailure failure =
                 | GameAlreadyStarted -> "the game has already started"))
         | CannotGiveInformation reasons ->
             ("Cannot give information", reasons |> List.map (function
+                | NoClockTokensAvailable -> "no clock tokens are available"
                 | NoMatchingCards -> "at least one card must match the information given"
                 | InvalidRecipient -> "the recipient must be one of the other players in the game"))
     let summary, reasons = (display failure)

--- a/HanabiGuru.Client.Console/Presentation.fs
+++ b/HanabiGuru.Client.Console/Presentation.fs
@@ -142,6 +142,9 @@ let commandFailure failure =
                 | WaitingForMinimumPlayers ->
                     sprintf "waiting for the minimum number of players (%i)" GameRules.minimumPlayers
                 | GameAlreadyStarted -> "the game has already started"))
+        | CannotGiveInformation reasons ->
+            ("Cannot give information", reasons |> List.map (function
+                | NoMatchingCards -> "at least one card must match the information given"))
     let summary, reasons = (display failure)
     message summary reasons |> printfn "%s"
 

--- a/HanabiGuru.Engine.Tests/AddPlayersTests.fs
+++ b/HanabiGuru.Engine.Tests/AddPlayersTests.fs
@@ -64,8 +64,7 @@ let ``Cannot add more than the maximum number of players`` (TooManyPlayers playe
     |> List.fold GameAction.perform (Ok EventHistory.empty) =! Error (CannotAddPlayer [NoSeatAvailable])
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Cannot add a player after game has started`` (GameReadyToStart game) (player : PlayerIdentity) =
-    Game.startGame :: [Game.addPlayer player]
-    |> List.fold GameAction.perform (Ok game)
+let ``Cannot add a player after game has started`` (GameInProgress game) (player : PlayerIdentity) =
+    Game.addPlayer player game
     |> Result.mapError (select CannotAddPlayerReason.GameAlreadyStarted)
         =! Error [CannotAddPlayerReason.GameAlreadyStarted]

--- a/HanabiGuru.Engine.Tests/DeductionTests.fs
+++ b/HanabiGuru.Engine.Tests/DeductionTests.fs
@@ -85,12 +85,7 @@ let ``The probabilities of candidate identities are relative to the number of un
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Candidate identities are returned in descending order of probability`` (GameReadyToStart game) =
-    let players = GameState.players game |> Set.toList
     let candidateProbabilities =
         Game.startGame game
         |> Result.map (candidateIdentities >> (List.map (List.map (List.map (fun candidate -> candidate.probability)))))
-        |> Result.map (fun candidates ->
-            candidates
-            |> List.collect id
-                >> List.map (fun candidate -> candidate.probability))))
     candidateProbabilities =! (candidateProbabilities |> Result.map (List.map (List.sortDescending)))

--- a/HanabiGuru.Engine.Tests/DeductionTests.fs
+++ b/HanabiGuru.Engine.Tests/DeductionTests.fs
@@ -13,79 +13,67 @@ let candidateIdentities game =
         |> List.map (PlayerView.CardIdentity.deduce view))
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``There is always at least one candidate identity for all cards`` (GameReadyToStart game) =
-    Game.startGame game
-    |> Result.map candidateIdentities
-    |> Result.map (fun candidates ->
-        candidates
-        |> List.collect id
-        |> List.filter List.isEmpty) =! Ok []
+let ``Each card always has a candidate identity for its true identity`` (GameInProgress game) =
+    let trueIdentities = GameState.hands game |> List.collect (fun hand -> hand.cards)
+
+    candidateIdentities game
+    |> List.collect id
+    |> List.map (List.map (fun candidate -> candidate.card))
+    |> List.map2 (fun trueIdentity -> List.filter ((=) trueIdentity)) trueIdentities
+        =! (trueIdentities |> List.map List.singleton)
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``All candidate identities always have a probability above zero and no greater than one`` (GameReadyToStart game) =
-    Game.startGame game
-    |> Result.map candidateIdentities
-    |> Result.map (fun candidates ->
-        candidates
-        |> List.collect id
-        |> List.collect id
-        |> List.filter (fun candidate -> candidate.probability <= 0.0 || candidate.probability > 1.0)) =! Ok []
+let ``All candidate identities always have a probability above zero and no greater than one`` (GameInProgress game) =
+    candidateIdentities game
+    |> List.collect id
+    |> List.collect id
+    |> List.filter (fun candidate -> candidate.probability <= 0.0 || candidate.probability > 1.0) =! []
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``The sum of probabilities for all candidates for each card is one`` (GameReadyToStart game) =
-    test <@ Game.startGame game
-        |> Result.map (candidateIdentities
-            >> List.map (List.map (List.sumBy (fun candidate -> candidate.probability)))
-            >> List.collect id
-            >> List.map ((-) 1.0 >> abs)
-            >> List.forall ((>) 1e-10)) = Ok true
+let ``The sum of probabilities for all candidates for each card is one`` (GameInProgress game) =
+    test <@ candidateIdentities game
+        |> List.map (List.map (List.sumBy (fun candidate -> candidate.probability)))
+        |> List.collect id
+        |> List.map ((-) 1.0 >> abs)
+        |> List.forall ((>) 1e-10)
     @>
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Candidate identities include all identities for which at least one card remains unrevealed``
-    (GameReadyToStart game) =
+    (GameInProgress game) =
 
-    let startedGameOrError = Game.startGame game
     let unrevealedCards =
-        startedGameOrError
-        |> Result.map (fun startedGame ->
-            GameState.hands startedGame
-            |> List.map (fun hand ->
-                    hand.cards
-                    |> List.append (GameState.drawDeck startedGame)
-                    |> List.replicate (List.length hand.cards)
-                    |> List.map set))
+        GameState.hands game
+        |> List.map (fun hand ->
+            hand.cards
+            |> List.append (GameState.drawDeck game)
+            |> List.replicate (List.length hand.cards)
+            |> List.map set)
 
-    startedGameOrError
-    |> Result.map (candidateIdentities >> List.map (List.map (List.map (fun candidate -> candidate.card) >> set)))
-        =! unrevealedCards
+    candidateIdentities game
+    |> List.map (List.map (List.map (fun candidate -> candidate.card) >> set)) =! unrevealedCards
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``The probabilities of candidate identities are relative to the number of unrevealed instances``
-    (GameReadyToStart game) =
+    (GameInProgress game) =
 
-    let startedGameOrError = Game.startGame game
     let unrevealedCards =
-        startedGameOrError
-        |> Result.map (fun startedGame ->
-            GameState.hands startedGame
-            |> List.map (fun hand ->
-                hand.cards
-                |> List.append (GameState.drawDeck startedGame)
-                |> List.replicate (List.length hand.cards)
-                |> List.map (List.countBy id
-                    >> List.sortByDescending (fun (card, count) -> (count, card))
-                    >> List.map fst)))
+        GameState.hands game
+        |> List.map (fun hand ->
+            hand.cards
+            |> List.append (GameState.drawDeck game)
+            |> List.replicate (List.length hand.cards)
+            |> List.map (List.countBy id
+                >> List.sortByDescending (fun (card, count) -> (count, card))
+                >> List.map fst))
     let sortCardsByProbability =
         List.sortByDescending (fun candidate -> (candidate.probability, candidate.card))
         >> List.map (fun candidate -> candidate.card)
 
-    startedGameOrError
-    |> Result.map (candidateIdentities >> List.map (List.map sortCardsByProbability)) =! unrevealedCards
+    candidateIdentities game |> List.map (List.map sortCardsByProbability) =! unrevealedCards
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Candidate identities are returned in descending order of probability`` (GameReadyToStart game) =
+let ``Candidate identities are returned in descending order of probability`` (GameInProgress game) =
     let candidateProbabilities =
-        Game.startGame game
-        |> Result.map (candidateIdentities >> (List.map (List.map (List.map (fun candidate -> candidate.probability)))))
-    candidateProbabilities =! (candidateProbabilities |> Result.map (List.map (List.sortDescending)))
+        candidateIdentities game |> (List.map (List.map (List.map (fun candidate -> candidate.probability))))
+    candidateProbabilities =! (candidateProbabilities |> List.map (List.sortDescending))

--- a/HanabiGuru.Engine.Tests/DeductionTests.fs
+++ b/HanabiGuru.Engine.Tests/DeductionTests.fs
@@ -6,7 +6,6 @@ open HanabiGuru.Engine
 
 let candidateIdentities game =
     GameState.players game
-    |> Set.toList
     |> List.map (fun player ->
         let view = GameState.playerView player game
         PlayerView.hand view
@@ -51,7 +50,6 @@ let private unrevealedCount player card game =
 
 let private probabilitiesAndCounts game =
     GameState.players game
-    |> Set.toList
     |> List.map (fun player ->
         let view = GameState.playerView player game
         PlayerView.hand view

--- a/HanabiGuru.Engine.Tests/GameAction.fs
+++ b/HanabiGuru.Engine.Tests/GameAction.fs
@@ -1,0 +1,3 @@
+﻿module HanabiGuru.Engine.Tests.GameAction
+
+let perform historyOrError action = Result.bind action historyOrError

--- a/HanabiGuru.Engine.Tests/GameGeneration.fs
+++ b/HanabiGuru.Engine.Tests/GameGeneration.fs
@@ -21,6 +21,7 @@ type FourOrMorePlayerGameInProgress = FourOrMorePlayerGameInProgress of EventHis
 type GameInProgress = GameInProgress of EventHistory
 type GameInProgressAndNextTurn = GameInProgressAndNextTurn of EventHistory * GameTurn
 type GameInProgressAndGiveInformationTurn = GameInProgressAndGiveInformationTurn of EventHistory * GiveInformationTurn
+type PlayerTurn = PlayerTurn of GameTurn
 
 type GameGeneration =
     static member private performAction game action =

--- a/HanabiGuru.Engine.Tests/GameGeneration.fs
+++ b/HanabiGuru.Engine.Tests/GameGeneration.fs
@@ -40,10 +40,11 @@ type GameGeneration =
         |> Gen.map2 GameGeneration.turns (Gen.sized (fun s -> Gen.choose (0, s)))
 
     static member private generateTurn game =
-        List.allPairs
-            (GameState.players game |> Set.toList)
-            [Blue; Green; Red; White; Yellow]
-        |> List.map (fun (player, suit) -> Game.giveInformation player suit)
+        [1..5]
+        |> List.map (Rank >> RankTrait)
+        |> List.append ([Blue; Green; Red; White; Yellow] |> List.map SuitTrait)
+        |> List.allPairs (GameState.players game |> Set.toList)
+        |> List.map (fun (player, cardTrait) -> Game.giveInformation player cardTrait)
         |> List.choose (fun action ->
             match action game with
             | Ok newGame -> Some (action, newGame)

--- a/HanabiGuru.Engine.Tests/GameGeneration.fs
+++ b/HanabiGuru.Engine.Tests/GameGeneration.fs
@@ -88,11 +88,9 @@ type GameGeneration =
         timeline
         |> Seq.take n
         |> Seq.tryFindBack (snd >> lastTurnPredicate)
-        |> Option.defaultValue
-            (timeline
-            |> Seq.skip n
-            |> Seq.take 10
-            |> Seq.find (snd >> lastTurnPredicate))
+        |> Option.map (fun x -> lazy x)
+        |> Option.defaultValue (lazy (timeline |> Seq.skip n |> Seq.find (snd >> lastTurnPredicate)))
+        |> fun l -> l.Value
 
     static member private classifyTurn = function
         | GameTurn.GiveInformation _ -> TurnClassification.GiveInformation

--- a/HanabiGuru.Engine.Tests/GameGeneration.fs
+++ b/HanabiGuru.Engine.Tests/GameGeneration.fs
@@ -58,17 +58,17 @@ type GameGeneration =
         | GameTurn.Pass -> Game.pass game
 
     static member private generateTurn game =
-        [1..5]
-        |> List.map (Rank >> RankTrait)
-        |> List.append ([Blue; Green; Red; White; Yellow] |> List.map SuitTrait)
-        |> List.allPairs (GameState.players game)
-        |> List.map (fun (player, cardTrait) -> GameTurn.GiveInformation (player, cardTrait))
-        |> List.append ([GameTurn.Pass])
-        |> List.choose (fun turn ->
+        seq [1..5]
+        |> Seq.map (Rank >> RankTrait)
+        |> Seq.append (seq [Blue; Green; Red; White; Yellow] |> Seq.map SuitTrait)
+        |> Seq.allPairs (GameState.players game)
+        |> Seq.map (fun (player, cardTrait) -> GameTurn.GiveInformation (player, cardTrait))
+        |> Seq.append (seq [GameTurn.Pass])
+        |> Seq.sortBy (ignore >> Random.double)
+        |> Seq.pick (fun turn ->
             match GameGeneration.executeTurn game turn with
             | Ok newGame -> Some (turn, newGame)
             | Error _ -> None)
-        |> List.randomItem Random.int
 
     static member private turns lastTurnPredicate n game =
         let timeline =

--- a/HanabiGuru.Engine.Tests/GameGeneration.fs
+++ b/HanabiGuru.Engine.Tests/GameGeneration.fs
@@ -43,7 +43,7 @@ type GameGeneration =
         [1..5]
         |> List.map (Rank >> RankTrait)
         |> List.append ([Blue; Green; Red; White; Yellow] |> List.map SuitTrait)
-        |> List.allPairs (GameState.players game |> Set.toList)
+        |> List.allPairs (GameState.players game)
         |> List.map (fun (player, cardTrait) -> Game.giveInformation player cardTrait)
         |> List.choose (fun action ->
             match action game with

--- a/HanabiGuru.Engine.Tests/GameGeneration.fs
+++ b/HanabiGuru.Engine.Tests/GameGeneration.fs
@@ -5,6 +5,7 @@ open HanabiGuru.Engine
 
 type TooManyPlayers = TooManyPlayers of Set<PlayerIdentity>
 type GameReadyToStart = GameReadyToStart of EventHistory
+type StartedGame = StartedGame of EventHistory
 type UpToThreePlayerGameInProgress = UpToThreePlayerGameInProgress of EventHistory
 type FourOrMorePlayerGameInProgress = FourOrMorePlayerGameInProgress of EventHistory
 type GameInProgress = GameInProgress of EventHistory
@@ -67,6 +68,10 @@ type GameGeneration =
     static member GameReadyToStart() =
         GameGeneration.generateGameReadyToStart GameRules.minimumPlayers GameRules.maximumPlayers
         |> GameGeneration.toArb GameReadyToStart
+
+    static member StartedGame() =
+        GameGeneration.generateStartedGame GameRules.minimumPlayers GameRules.maximumPlayers
+        |> GameGeneration.toArb StartedGame
 
     static member UpToThreePlayerGameInProgress() =
         GameGeneration.generateGameInProgress GameRules.minimumPlayers 3

--- a/HanabiGuru.Engine.Tests/GameGeneration.fs
+++ b/HanabiGuru.Engine.Tests/GameGeneration.fs
@@ -5,25 +5,30 @@ open HanabiGuru.Engine
 
 type TooManyPlayers = TooManyPlayers of Set<PlayerIdentity>
 type GameReadyToStart = GameReadyToStart of EventHistory
-type UpToThreePlayerGameReadyToStart = UpToThreePlayerGameReadyToStart of EventHistory
-type FourOrMorePlayerGameReadyToStart = FourOrMorePlayerGameReadyToStart of EventHistory
+type UpToThreePlayerGameInProgress = UpToThreePlayerGameInProgress of EventHistory
+type FourOrMorePlayerGameInProgress = FourOrMorePlayerGameInProgress of EventHistory
+type GameInProgress = GameInProgress of EventHistory
 
 type GameGeneration =
-    static member private gameReadyToStart minPlayers maxPlayers =
-        let addPlayers players =
-            let performAction game action =
-                match action game with
-                | Ok newGame -> newGame
-                | Error _ -> game
-            players
-            |> List.map Game.addPlayer
-            |> List.fold performAction EventHistory.empty
+    static member private performAction game action =
+        match action game with
+        | Ok newGame -> newGame
+        | Error _ -> game
 
+    static member private playGame players =
+        List.append (List.map Game.addPlayer players)
+        >> List.fold GameGeneration.performAction EventHistory.empty
+
+    static member private generateGameWithPlayerCount minPlayers maxPlayers actions =
         Arb.generate<Set<PlayerIdentity>> 
         |> Gen.filter (Set.count >> ((<=) minPlayers)) 
         |> Gen.filter (Set.count >> ((>=) maxPlayers)) 
-        |> Gen.map (Set.toList >> addPlayers)
-    
+        |> Gen.map (Set.toList)
+        |> Gen.map (fun players -> GameGeneration.playGame players actions)
+
+    static member private generateGame =
+        GameGeneration.generateGameWithPlayerCount GameRules.minimumPlayers GameRules.maximumPlayers
+
     static member private toArb arbType = Gen.map arbType >> Arb.fromGen
 
     static member TooManyPlayers() =
@@ -32,13 +37,20 @@ type GameGeneration =
         |> GameGeneration.toArb TooManyPlayers
 
     static member GameReadyToStart() =
-        GameGeneration.gameReadyToStart GameRules.minimumPlayers GameRules.maximumPlayers
+        GameGeneration.generateGame []
         |> GameGeneration.toArb GameReadyToStart
 
-    static member UpToThreePlayerGameReadyToStart() =
-        GameGeneration.gameReadyToStart GameRules.minimumPlayers 3
-        |> GameGeneration.toArb UpToThreePlayerGameReadyToStart
+    static member UpToThreePlayerGameInProgress() =
+        [Game.startGame]
+        |> GameGeneration.generateGameWithPlayerCount GameRules.minimumPlayers 3
+        |> GameGeneration.toArb UpToThreePlayerGameInProgress
 
-    static member FourOrMorePlayerGameReadyToStart() =
-        GameGeneration.gameReadyToStart 4 GameRules.maximumPlayers
-        |> GameGeneration.toArb FourOrMorePlayerGameReadyToStart
+    static member FourOrMorePlayerGameInProgress() =
+        [Game.startGame]
+        |> GameGeneration.generateGameWithPlayerCount 4 GameRules.maximumPlayers
+        |> GameGeneration.toArb FourOrMorePlayerGameInProgress
+
+    static member GameInProgress() =
+        [Game.startGame]
+        |> GameGeneration.generateGame
+        |> GameGeneration.toArb GameInProgress

--- a/HanabiGuru.Engine.Tests/GameGeneration.fs
+++ b/HanabiGuru.Engine.Tests/GameGeneration.fs
@@ -51,7 +51,7 @@ type GameGeneration =
 
     static member private generateGameInProgressAndNextTurn minPlayers maxPlayers nextTurnPredicate =
         GameGeneration.generateStartedGame minPlayers maxPlayers
-        |> Gen.map2 (GameGeneration.turns nextTurnPredicate) (Gen.sized (fun s -> Gen.choose (0, s)))
+        |> Gen.map2 (GameGeneration.turns nextTurnPredicate) (Gen.sized (fun s -> Gen.choose (0, max 0 s)))
 
     static member executeTurn game = function
         | GameTurn.GiveInformation (player, cardTrait) -> Game.giveInformation player cardTrait game

--- a/HanabiGuru.Engine.Tests/GameGeneration.fs
+++ b/HanabiGuru.Engine.Tests/GameGeneration.fs
@@ -45,6 +45,7 @@ type GameGeneration =
         |> List.append ([Blue; Green; Red; White; Yellow] |> List.map SuitTrait)
         |> List.allPairs (GameState.players game)
         |> List.map (fun (player, cardTrait) -> Game.giveInformation player cardTrait)
+        |> List.append ([Game.pass])
         |> List.choose (fun action ->
             match action game with
             | Ok newGame -> Some (action, newGame)

--- a/HanabiGuru.Engine.Tests/GameGeneration.fs
+++ b/HanabiGuru.Engine.Tests/GameGeneration.fs
@@ -28,7 +28,7 @@ type GameGeneration =
         Arb.generate<Set<PlayerIdentity>> 
         |> Gen.filter (Set.count >> ((<=) minPlayers)) 
         |> Gen.filter (Set.count >> ((>=) maxPlayers)) 
-        |> Gen.map (Set.toList)
+        |> Gen.map (Set.toList >> List.sortBy (ignore >> Random.double))
         |> Gen.map (fun players -> GameGeneration.addPlayers players)
 
     static member private generateStartedGame minPlayers maxPlayers =

--- a/HanabiGuru.Engine.Tests/GameStateTests.fs
+++ b/HanabiGuru.Engine.Tests/GameStateTests.fs
@@ -131,3 +131,15 @@ let ``Play passes in turn order`` (GameInProgressAndNextTurn (game, nextTurn)) =
             |> PlayerView.otherPlayers
             |> List.head)
     GameGeneration.executeTurn game nextTurn |> Result.map GameState.activePlayer =! Ok nextPlayer
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Cannot take player turn before the game has started`` (players : Set<PlayerIdentity>) (PlayerTurn turn) =
+    let players =
+        players
+        |> Set.toList
+        |> List.truncate GameRules.maximumPlayers
+    players
+    |> List.map Game.addPlayer
+    |> List.fold GameAction.perform (Ok EventHistory.empty)
+    |> Result.bind (fun game -> GameGeneration.executeTurn game turn)
+        =! Error (CannotTakeTurn [GameNotStarted])

--- a/HanabiGuru.Engine.Tests/GameStateTests.fs
+++ b/HanabiGuru.Engine.Tests/GameStateTests.fs
@@ -53,10 +53,26 @@ let ``Players see the fuse tokens`` (GameInProgress game) =
     |> List.map PlayerView.fuseTokens =! (List.map (fun _ -> GameState.fuseTokens game) players)
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``There is always at least one fuse token remaining in a game which is still in progress`` (GameInProgress game) =
+    GameState.fuseTokens game >=! 1
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``The number of fuse tokens remaining never increases`` (GameInProgressAndNextTurn (game, turn)) =
+    GameState.fuseTokens game >=! (GameState.fuseTokens <| turn game)
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Players see the clock tokens`` (GameInProgress game) =
     let players = GameState.players game
     List.map (fun player -> GameState.playerView player game) players
     |> List.map PlayerView.clockTokens =! (List.map (fun _ -> GameState.clockTokens game) players)
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``The number of clock tokens remaining never drops below zero`` (GameInProgress game) =
+    GameState.clockTokens game >=! 0
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``The number of clock tokens remaining never exceeds the initial number available`` (GameInProgress game) =
+    GameState.clockTokens game <=! GameRules.clockTokensAvailable
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Players see the number of cards in the draw deck`` (GameInProgress game) =

--- a/HanabiGuru.Engine.Tests/GameStateTests.fs
+++ b/HanabiGuru.Engine.Tests/GameStateTests.fs
@@ -1,0 +1,98 @@
+﻿module HanabiGuru.Engine.Tests.GameStateTests
+
+open FsCheck.Xunit
+open Swensen.Unquote
+open HanabiGuru.Engine
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``The game always contains all cards`` (GameInProgress game) =
+    let expectedCounts =
+        [
+            (Blue, Rank 1), 3
+            (Blue, Rank 2), 2
+            (Blue, Rank 3), 2
+            (Blue, Rank 4), 2
+            (Blue, Rank 5), 1
+            (Green, Rank 1), 3
+            (Green, Rank 2), 2
+            (Green, Rank 3), 2
+            (Green, Rank 4), 2
+            (Green, Rank 5), 1
+            (Red, Rank 1), 3
+            (Red, Rank 2), 2
+            (Red, Rank 3), 2
+            (Red, Rank 4), 2
+            (Red, Rank 5), 1
+            (White, Rank 1), 3
+            (White, Rank 2), 2
+            (White, Rank 3), 2
+            (White, Rank 4), 2
+            (White, Rank 5), 1
+            (Yellow, Rank 1), 3
+            (Yellow, Rank 2), 2
+            (Yellow, Rank 3), 2
+            (Yellow, Rank 4), 2
+            (Yellow, Rank 5), 1
+        ]
+        |> List.map (Pair.mapFst Card)
+        |> List.sort
+
+    let allCards game =
+        let cardsInHands = GameState.hands game |> List.map (fun hand -> hand.cards)
+        GameState.drawDeck game :: cardsInHands
+        |> List.collect id
+
+    allCards game |> List.countBy id |> List.sort =! expectedCounts
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Players see the fuse tokens`` (GameInProgress game) =
+    let players = GameState.players game |> Set.toList
+    List.map (fun player -> GameState.playerView player game) players
+    |> List.map PlayerView.fuseTokens =! (List.map (fun _ -> GameState.fuseTokens game) players)
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Players see the clock tokens`` (GameInProgress game) =
+    let players = GameState.players game |> Set.toList
+    List.map (fun player -> GameState.playerView player game) players
+    |> List.map PlayerView.clockTokens =! (List.map (fun _ -> GameState.clockTokens game) players)
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Players see the number of cards in the draw deck`` (GameInProgress game) =
+    let players = GameState.players game |> Set.toList
+    let expectedResult =
+        GameState.drawDeck game
+        |> List.length
+        |> List.replicate (List.length players)
+
+    List.map (fun player -> GameState.playerView player game) players
+    |> List.map PlayerView.drawDeckSize =! expectedResult
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Each player always has five cards in a two or three player game`` (UpToThreePlayerGameInProgress game) =
+    GameState.hands game
+    |> List.map (fun hand -> (hand.player, List.length hand.cards))
+        =! (GameState.players game |> Set.toList |> List.map (fun player -> (player, 5)))
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Each player always has four cards in a four or five player game`` (FourOrMorePlayerGameInProgress game) =
+    GameState.hands game
+    |> List.map (fun hand -> (hand.player, List.length hand.cards))
+        =! (GameState.players game |> Set.toList |> List.map (fun player -> (player, 4)))
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Players see the cards in the hands of the other players`` (GameInProgress game) =
+    let players = GameState.players game |> Set.toList
+    let expectedOtherHands player =
+        GameState.hands game
+        |> List.filter (fun hand -> hand.player <> player)
+
+    List.map (fun player -> GameState.playerView player game) players
+    |> List.map PlayerView.otherHands =! (List.map expectedOtherHands players)
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``An unstarted game has no active player`` (GameReadyToStart game) =
+    GameState.activePlayer game =! None
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``After starting the game, there is always an active player`` (GameInProgress game) =
+    GameState.activePlayer game <>! None

--- a/HanabiGuru.Engine.Tests/GameStateTests.fs
+++ b/HanabiGuru.Engine.Tests/GameStateTests.fs
@@ -48,19 +48,19 @@ let ``The game always contains all cards`` (GameInProgress game) =
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Players see the fuse tokens`` (GameInProgress game) =
-    let players = GameState.players game |> Set.toList
+    let players = GameState.players game
     List.map (fun player -> GameState.playerView player game) players
     |> List.map PlayerView.fuseTokens =! (List.map (fun _ -> GameState.fuseTokens game) players)
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Players see the clock tokens`` (GameInProgress game) =
-    let players = GameState.players game |> Set.toList
+    let players = GameState.players game
     List.map (fun player -> GameState.playerView player game) players
     |> List.map PlayerView.clockTokens =! (List.map (fun _ -> GameState.clockTokens game) players)
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Players see the number of cards in the draw deck`` (GameInProgress game) =
-    let players = GameState.players game |> Set.toList
+    let players = GameState.players game
     let expectedResult =
         GameState.drawDeck game
         |> List.length
@@ -73,17 +73,17 @@ let ``Players see the number of cards in the draw deck`` (GameInProgress game) =
 let ``Each player always has five cards in a two or three player game`` (UpToThreePlayerGameInProgress game) =
     GameState.hands game
     |> List.map (fun hand -> (hand.player, List.length hand.cards))
-        =! (GameState.players game |> Set.toList |> List.map (fun player -> (player, 5)))
+        =! (GameState.players game |> List.map (fun player -> (player, 5)))
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Each player always has four cards in a four or five player game`` (FourOrMorePlayerGameInProgress game) =
     GameState.hands game
     |> List.map (fun hand -> (hand.player, List.length hand.cards))
-        =! (GameState.players game |> Set.toList |> List.map (fun player -> (player, 4)))
+        =! (GameState.players game |> List.map (fun player -> (player, 4)))
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Players see the cards in the hands of the other players`` (GameInProgress game) =
-    let players = GameState.players game |> Set.toList
+    let players = GameState.players game
     let expectedOtherHands player =
         GameState.hands game
         |> List.filter (fun hand -> hand.player <> player)

--- a/HanabiGuru.Engine.Tests/GameStateTests.fs
+++ b/HanabiGuru.Engine.Tests/GameStateTests.fs
@@ -38,7 +38,9 @@ let ``The game always contains all cards`` (GameInProgress game) =
         |> List.sort
 
     let allCards game =
-        let cardsInHands = GameState.hands game |> List.map (fun hand -> hand.cards)
+        let cardsInHands =
+            GameState.hands game
+            |> List.map (fun hand -> hand.cards |> List.map (fun { identity = card } -> card))
         GameState.drawDeck game :: cardsInHands
         |> List.collect id
 

--- a/HanabiGuru.Engine.Tests/GameStateTests.fs
+++ b/HanabiGuru.Engine.Tests/GameStateTests.fs
@@ -96,3 +96,13 @@ let ``An unstarted game has no active player`` (GameReadyToStart game) =
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``After starting the game, there is always an active player`` (GameInProgress game) =
     GameState.activePlayer game <>! None
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Play passes in turn order`` (GameInProgressAndNextTurn (game, nextTurn)) =
+    let nextPlayer =
+        GameState.activePlayer game
+        |> Option.map (fun activePlayer ->
+            GameState.playerView activePlayer game
+            |> PlayerView.otherPlayers
+            |> List.head)
+    nextTurn game |> Result.map GameState.activePlayer =! Ok nextPlayer

--- a/HanabiGuru.Engine.Tests/GameStateTests.fs
+++ b/HanabiGuru.Engine.Tests/GameStateTests.fs
@@ -58,7 +58,7 @@ let ``There is always at least one fuse token remaining in a game which is still
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``The number of fuse tokens remaining never increases`` (GameInProgressAndNextTurn (game, turn)) =
-    GameState.fuseTokens game >=! (GameState.fuseTokens <| turn game)
+    GameState.fuseTokens game >=! (GameState.fuseTokens <| GameGeneration.executeTurn game turn)
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Players see the clock tokens`` (GameInProgress game) =
@@ -130,4 +130,4 @@ let ``Play passes in turn order`` (GameInProgressAndNextTurn (game, nextTurn)) =
             GameState.playerView activePlayer game
             |> PlayerView.otherPlayers
             |> List.head)
-    nextTurn game |> Result.map GameState.activePlayer =! Ok nextPlayer
+    GameGeneration.executeTurn game nextTurn |> Result.map GameState.activePlayer =! Ok nextPlayer

--- a/HanabiGuru.Engine.Tests/GameStateTests.fs
+++ b/HanabiGuru.Engine.Tests/GameStateTests.fs
@@ -87,9 +87,16 @@ let ``Players see the cards in the hands of the other players`` (GameInProgress 
     let expectedOtherHands player =
         GameState.hands game
         |> List.filter (fun hand -> hand.player <> player)
+        |> List.sortBy (fun hand -> hand.player)
 
-    List.map (fun player -> GameState.playerView player game) players
-    |> List.map PlayerView.otherHands =! (List.map expectedOtherHands players)
+    players
+    |> List.map (fun player ->
+        let view = GameState.playerView player game
+        view
+        |> PlayerView.otherPlayers
+        |> List.map (fun otherPlayer -> PlayerView.otherHand otherPlayer view)
+        |> List.sortBy (fun hand -> hand.player))
+    =! (List.map expectedOtherHands players)
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``An unstarted game has no active player`` (GameReadyToStart game) =

--- a/HanabiGuru.Engine.Tests/GiveInformationTests.fs
+++ b/HanabiGuru.Engine.Tests/GiveInformationTests.fs
@@ -46,7 +46,6 @@ let ``Information is given to the recipient only`` (GameInProgress game) (cardTr
 
     let bystandersDeductions game =
         GameState.players game
-        |> Set.toList
         |> List.filter ((<>) recipient)
         |> List.map (fun player ->
             let view = GameState.playerView player game

--- a/HanabiGuru.Engine.Tests/GiveInformationTests.fs
+++ b/HanabiGuru.Engine.Tests/GiveInformationTests.fs
@@ -54,9 +54,7 @@ let private select reason = function
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Giving information becomes impossible once the clock tokens are exhausted``
-    (GameInProgress game)
-    (recipient : PlayerIdentity)
-    (cardTrait : CardTrait) =
+    (GameInProgressAndGiveInformationTurn (game, (recipient, cardTrait))) =
 
     Game.giveInformation recipient cardTrait
     |> List.replicate (GameState.clockTokens game + 1)

--- a/HanabiGuru.Engine.Tests/GiveInformationTests.fs
+++ b/HanabiGuru.Engine.Tests/GiveInformationTests.fs
@@ -11,13 +11,8 @@ let ``After each player gives information to the next player, there are fewer ca
 
     let startedGame = Game.startGame game
     let players = GameState.players game |> Set.toList
-    let candidateIdentities game =
-        players
-        |> List.map (fun player ->
-            let view = GameState.playerView player game
-            PlayerView.hand view
-            |> List.map (PlayerView.CardIdentity.deduce view))
-    let candidateCards = candidateIdentities >> List.collect id >> List.map (List.map (fun candidate -> candidate.card))
+    let candidateCards =
+        DeductionTests.candidateIdentities >> List.collect (List.map (List.map (fun candidate -> candidate.card)))
     let giveInfoToNextPlayer game =
         let activePlayer = GameState.activePlayer game |> Option.get
         let playerView = GameState.playerView activePlayer game
@@ -35,4 +30,7 @@ let ``After each player gives information to the next player, there are fewer ca
                 candidates
                 |> List.zip initialCandidates))
 
-    test <@ pairedCandidates |> Result.map (List.forall (fun (initial, informed) -> informed < initial)) = Ok true @>
+    test <@ pairedCandidates
+        |> Result.map (List.map (Pair.map List.length)
+            >> List.forall (fun (initial, informed) -> informed < initial)) = Ok true @>
+

--- a/HanabiGuru.Engine.Tests/GiveInformationTests.fs
+++ b/HanabiGuru.Engine.Tests/GiveInformationTests.fs
@@ -21,6 +21,18 @@ let private legalAction recipientIndex cardIndex cardTrait game =
     |> Option.get
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Giving information costs a clock token``
+    (GameInProgress game)
+    (PositiveInt recipientIndex)
+    (PositiveInt cardIndex)
+    (cardTrait : CardTrait) =
+
+    let (recipient, cardTrait) = legalAction recipientIndex cardIndex cardTrait game
+
+    Game.giveInformation recipient cardTrait game
+    |> Result.map (GameState.clockTokens) =! Ok (GameState.clockTokens game - 1)
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``For each card in the recipients hand, all or none of the candidate identities must match the trait``
     (GameInProgress game)
     (PositiveInt recipientIndex)

--- a/HanabiGuru.Engine.Tests/GiveInformationTests.fs
+++ b/HanabiGuru.Engine.Tests/GiveInformationTests.fs
@@ -1,0 +1,38 @@
+﻿module HanabiGuru.Engine.Tests.GiveInformationTests
+
+open FsCheck.Xunit
+open Swensen.Unquote
+open HanabiGuru.Engine
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``After each player gives information to the next player, there are fewer candidate identities for each card``
+    (GameReadyToStart game)
+    (suit : Suit) =
+
+    let startedGame = Game.startGame game
+    let players = GameState.players game |> Set.toList
+    let candidateIdentities game =
+        players
+        |> List.map (fun player ->
+            let view = GameState.playerView player game
+            PlayerView.hand view
+            |> List.map (PlayerView.CardIdentity.deduce view))
+    let candidateCards = candidateIdentities >> List.collect id >> List.map (List.map (fun candidate -> candidate.card))
+    let giveInfoToNextPlayer game =
+        let activePlayer = GameState.activePlayer game |> Option.get
+        let playerView = GameState.playerView activePlayer game
+        let nextPlayer = PlayerView.otherPlayers playerView |> List.head
+        Game.giveInformation nextPlayer suit game
+
+    let pairedCandidates =
+        List.replicate (List.length players) giveInfoToNextPlayer
+        |> List.fold GameAction.perform startedGame
+        |> Result.map candidateCards
+        |> Result.bind (fun candidates ->
+            startedGame
+            |> Result.map candidateCards
+            |> Result.map (fun initialCandidates ->
+                candidates
+                |> List.zip initialCandidates))
+
+    test <@ pairedCandidates |> Result.map (List.forall (fun (initial, informed) -> informed < initial)) = Ok true @>

--- a/HanabiGuru.Engine.Tests/GiveInformationTests.fs
+++ b/HanabiGuru.Engine.Tests/GiveInformationTests.fs
@@ -97,7 +97,16 @@ let ``Cannot give information to another player which no cards match`` (GameInPr
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Cannot give information to self`` (GameInProgress game) (cardTrait : CardTrait) =
     Game.giveInformation (GameState.activePlayer game |> Option.get) cardTrait game
-        =! Error (CannotGiveInformation [CannotGiveInformationReason.InvalidRecipient])
+    |> Result.mapError (select CannotGiveInformationReason.InvalidRecipient)
+        =! Error [CannotGiveInformationReason.InvalidRecipient]
+
+[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
+let ``Giving information to self does not reveal the fact that no cards match``
+    (GameInProgress game)
+    (cardTrait : CardTrait) =
+
+    Game.giveInformation (GameState.activePlayer game |> Option.get) cardTrait game
+    |> Result.mapError (select CannotGiveInformationReason.NoMatchingCards) =! Error []
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Cannot give information to a player who has not joined the game``

--- a/HanabiGuru.Engine.Tests/HanabiGuru.Engine.Tests.fsproj
+++ b/HanabiGuru.Engine.Tests/HanabiGuru.Engine.Tests.fsproj
@@ -66,6 +66,7 @@
     <Compile Include="GameAction.fs" />
     <Compile Include="AddPlayersTests.fs" />
     <Compile Include="StartGameTests.fs" />
+    <Compile Include="GameStateTests.fs" />
     <Compile Include="DeductionTests.fs" />
     <Compile Include="GiveInformationTests.fs" />
   </ItemGroup>

--- a/HanabiGuru.Engine.Tests/HanabiGuru.Engine.Tests.fsproj
+++ b/HanabiGuru.Engine.Tests/HanabiGuru.Engine.Tests.fsproj
@@ -63,6 +63,7 @@
     <Compile Include="ResultTests.fs" />
     <Compile Include="GameGeneration.fs" />
     <Compile Include="EventHistoryTests.fs" />
+    <Compile Include="GameAction.fs" />
     <Compile Include="AddPlayersTests.fs" />
     <Compile Include="StartGameTests.fs" />
     <Compile Include="DeductionTests.fs" />

--- a/HanabiGuru.Engine.Tests/HanabiGuru.Engine.Tests.fsproj
+++ b/HanabiGuru.Engine.Tests/HanabiGuru.Engine.Tests.fsproj
@@ -67,6 +67,7 @@
     <Compile Include="AddPlayersTests.fs" />
     <Compile Include="StartGameTests.fs" />
     <Compile Include="DeductionTests.fs" />
+    <Compile Include="GiveInformationTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsCheck">

--- a/HanabiGuru.Engine.Tests/StartGameTests.fs
+++ b/HanabiGuru.Engine.Tests/StartGameTests.fs
@@ -1,4 +1,4 @@
-﻿module HanabiGuru.Engine.Tests.GameTests
+﻿module HanabiGuru.Engine.Tests.StartGameTests
 
 open FsCheck
 open FsCheck.Xunit
@@ -29,134 +29,12 @@ let ``Starting the game adds the fuse tokens to the game`` (GameReadyToStart gam
     |> Result.map GameState.fuseTokens =! Ok GameRules.fuseTokensAvailable
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Players see the fuse tokens after starting the game`` (GameReadyToStart game) =
-    let players = GameState.players game |> Set.toList
-    Game.startGame game
-    |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
-    |> Result.map (List.map PlayerView.fuseTokens) =! Ok (List.map (fun _ -> GameRules.fuseTokensAvailable) players)
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Starting the game adds the clock tokens to the game`` (GameReadyToStart game) =
     Game.startGame game
     |> Result.map GameState.clockTokens =! Ok GameRules.clockTokensAvailable
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Players see the clock tokens after starting the game`` (GameReadyToStart game) =
-    let players = GameState.players game |> Set.toList
-    Game.startGame game
-    |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
-    |> Result.map (List.map PlayerView.clockTokens) =! Ok (List.map (fun _ -> GameRules.clockTokensAvailable) players)
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Starting the game adds the standard set of cards to the game`` (GameReadyToStart game) =
-    let expectedCounts =
-        [
-            (Blue, Rank 1), 3
-            (Blue, Rank 2), 2
-            (Blue, Rank 3), 2
-            (Blue, Rank 4), 2
-            (Blue, Rank 5), 1
-            (Green, Rank 1), 3
-            (Green, Rank 2), 2
-            (Green, Rank 3), 2
-            (Green, Rank 4), 2
-            (Green, Rank 5), 1
-            (Red, Rank 1), 3
-            (Red, Rank 2), 2
-            (Red, Rank 3), 2
-            (Red, Rank 4), 2
-            (Red, Rank 5), 1
-            (White, Rank 1), 3
-            (White, Rank 2), 2
-            (White, Rank 3), 2
-            (White, Rank 4), 2
-            (White, Rank 5), 1
-            (Yellow, Rank 1), 3
-            (Yellow, Rank 2), 2
-            (Yellow, Rank 3), 2
-            (Yellow, Rank 4), 2
-            (Yellow, Rank 5), 1
-        ]
-        |> List.map (Pair.mapFst Card)
-        |> List.sort
-
-    let allCards game =
-        let cardsInHands = GameState.hands game |> List.map (fun hand -> hand.cards)
-        GameState.drawDeck game :: cardsInHands
-        |> List.collect id
-
-    Game.startGame game
-    |> Result.map (allCards >> List.countBy id >> List.sort) =! Ok expectedCounts
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Players see the number of cards in the draw deck`` (GameReadyToStart game) =
-    let players = GameState.players game |> Set.toList
-    let startedGame = Game.startGame game
-    let expectedResult =
-        startedGame
-        |> Result.map GameState.drawDeck
-        |> Result.map List.length
-        |> List.replicate (List.length players)
-        |> Result.collect
-        |> Result.mapError List.head
-    startedGame
-    |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
-    |> Result.map (List.map PlayerView.drawDeckSize) =! expectedResult
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Starting the game deals cards to each player`` (GameReadyToStart game) =
-    Game.startGame game
-    |> Result.map (GameState.hands >> List.map (fun hand -> hand.player)) =! Ok (GameState.players game |> Set.toList)
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Starting the game deals five cards each for two or three players`` (UpToThreePlayerGameReadyToStart game) =
-    Game.startGame game
-    |> Result.map (GameState.hands >> List.map (fun hand -> hand.cards) >> List.map List.length)
-        =! Ok (List.replicate (GameState.players game |> Set.count) 5)
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Starting the game deals four cards each for four or five players`` (FourOrMorePlayerGameReadyToStart game) =
-    Game.startGame game
-    |> Result.map (GameState.hands >> List.map (fun hand -> hand.cards) >> List.map List.length)
-        =! Ok (List.replicate (GameState.players game |> Set.count) 4)
 
 [<Property(Arbitrary = [| typeof<GameGeneration> |])>]
 let ``Starting the game deals the initial hands non-deterministically`` (GameReadyToStart game) =
     List.replicate 5 game
     |> List.distinctBy Game.startGame
     |> List.length >! 1
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Each player has the same number of cards in their hands`` (GameReadyToStart game) =
-    let players = GameState.players game |> Set.toList
-    let handSizes view =
-        (PlayerView.hand view |> List.length)
-        :: (PlayerView.otherHands view |> List.map (fun hand -> hand.cards) |> List.map List.length)
-
-    test <@ Game.startGame game
-    |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
-    |> Result.map (List.collect handSizes)
-    |> Result.map List.distinct
-    |> Result.map List.length = Ok 1 @>
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Players see the cards in the hands of the other players`` (GameReadyToStart game) =
-    let players = GameState.players game |> Set.toList
-    let startedGame = Game.startGame game
-    let expectedOtherHands player =
-        startedGame
-        |> Result.map GameState.hands
-        |> Result.map (List.filter (fun hand -> hand.player <> player))
-
-    startedGame
-    |> Result.map (fun game -> List.map (fun player -> GameState.playerView player game) players)
-    |> Result.map (List.map PlayerView.otherHands)
-        =! (List.map expectedOtherHands players |> Result.collect |> Result.mapError List.head)
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``An unstarted game has no active player`` (GameReadyToStart game) =
-    game |> GameState.activePlayer =! None
-
-[<Property(Arbitrary = [| typeof<GameGeneration> |])>]
-let ``Starting the game makes one of the players active`` (GameReadyToStart game) =
-    Game.startGame game |> Result.map GameState.activePlayer <>! Ok None

--- a/HanabiGuru.Engine/Card.fs
+++ b/HanabiGuru.Engine/Card.fs
@@ -1,5 +1,7 @@
 ﻿namespace HanabiGuru.Engine
 
+open System
+
 type Suit =
     | Blue
     | Green
@@ -11,10 +13,32 @@ type Rank = Rank of int
 
 type Card = Card of Suit * Rank
 
-type ConcealedCard = ConcealedCard
+type CardInstanceKey = CardInstanceKey of Guid
+
+type ConcealedCard = ConcealedCard of CardInstanceKey
 
 type CandidateIdentity =
     {
         card : Card
         probability : double
     }
+
+type CardInstance =
+    {
+        instanceKey : CardInstanceKey
+        identity : Card
+    }
+
+type CardTraitMatch =
+    | Matches of Suit
+    | DoesNotMatch of Suit
+
+module CardInstance =
+
+    let nextInstanceKey () = CardInstanceKey (Guid.NewGuid())
+
+    let create key card =
+        {
+            instanceKey = key
+            identity = card
+        }

--- a/HanabiGuru.Engine/Card.fs
+++ b/HanabiGuru.Engine/Card.fs
@@ -37,6 +37,8 @@ type CardTraitMatch =
     | Matches of CardTrait
     | DoesNotMatch of CardTrait
 
+type CardInformation = CardInformation of CardInstanceKey * CardTraitMatch
+
 module CardInstance =
 
     let nextInstanceKey () = CardInstanceKey (Guid.NewGuid())

--- a/HanabiGuru.Engine/Card.fs
+++ b/HanabiGuru.Engine/Card.fs
@@ -29,9 +29,13 @@ type CardInstance =
         identity : Card
     }
 
+type CardTrait =
+    | SuitTrait of Suit
+    | RankTrait of Rank
+
 type CardTraitMatch =
-    | Matches of Suit
-    | DoesNotMatch of Suit
+    | Matches of CardTrait
+    | DoesNotMatch of CardTrait
 
 module CardInstance =
 

--- a/HanabiGuru.Engine/EventHistory.fs
+++ b/HanabiGuru.Engine/EventHistory.fs
@@ -29,3 +29,5 @@ module EventHistory =
     let choose f = events >> List.choose f
 
     let tryPick f = List.tryPick f |> apply
+
+    let inline sumBy f = events >> List.sumBy f

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -10,6 +10,7 @@ type CannotStartGameReason =
     | GameAlreadyStarted
 
 type CannotGiveInformationReason =
+    | NoClockTokensAvailable
     | NoMatchingCards
     | InvalidRecipient
 

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -59,7 +59,7 @@ module Game =
                 |> List.map Card
             let players = GameState.players history
             let cardsDealt = GameAction.dealInitialHands drawDeck players
-            let firstPlayer = Set.minElement players
+            let firstPlayer = List.head players
             (drawDeck |> List.map CardAddedToDrawDeck)
             @ (cardsDealt |> List.map CardDealtToPlayer)
             @ [StartTurn firstPlayer]
@@ -71,7 +71,7 @@ module Game =
 
         let createEvents () =
             Seq.initInfinite (fun _ -> GameState.players history)
-            |> Seq.collect Set.toSeq
+            |> Seq.collect id
             |> Seq.skipWhile (Some >> (<>) (GameState.activePlayer history))
             |> Seq.skip 1
             |> Seq.take 1

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -11,6 +11,7 @@ type CannotStartGameReason =
 
 type CannotGiveInformationReason =
     | NoMatchingCards
+    | InvalidRecipient
 
 type CannotPerformAction =
     | CannotAddPlayer of CannotAddPlayerReason list
@@ -81,9 +82,15 @@ module Game =
             | CardInformation (_, Matches _) -> true
             | CardInformation (_, DoesNotMatch _) -> false
 
+        let recipientIsSelf = GameState.activePlayer >> ((=) (Some recipient))
+
+        let noMatchingCards history =
+            (determineInfo history |> List.forall (not << isMatch)) && not (recipientIsSelf history)
+
         let rules =
             [
-                NoMatchingCards, determineInfo >> List.forall (not << isMatch)
+                NoMatchingCards, noMatchingCards
+                InvalidRecipient, recipientIsSelf
             ]
 
         let createEvents () =

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -69,6 +69,8 @@ module Game =
     let giveInformation _ _ =
         let rules = []
 
-        let createEvents () = []
+        let createEvents () =
+            [Blue; Green; Red; Yellow; White]
+            |> List.map (fun suit -> InformationGiven (Card (suit, Rank 5)))
 
         performAction rules createEvents CannotStartGame

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -74,6 +74,18 @@ module Game =
 
         performAction rules createEvents CannotStartGame history
 
+    let pass history =
+        let rules = []
+
+        let createEvents () =
+            GameAction.nextPlayer
+                (GameState.players history)
+                (GameState.activePlayer history |> Option.get)
+                |> StartTurn
+                |> List.singleton
+
+        performAction rules createEvents CannotGiveInformation history
+
     let giveInformation recipient cardTrait history =
         let determineInfo =
             GameState.hands

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -81,7 +81,8 @@ module Game =
                 |> List.filter (fun hand -> hand.player = recipient)
                 |> List.collect (fun hand -> hand.cards)
                 |> List.map (function
-                    | { instanceKey = key; identity = Card (suit, _) } when suit = cardTrait ->
+                    | { instanceKey = key; identity = Card (suit, rank) }
+                        when SuitTrait suit = cardTrait || RankTrait rank = cardTrait ->
                         InformationGiven (key, Matches cardTrait)
                     | { instanceKey = key } ->
                         InformationGiven (key, DoesNotMatch cardTrait)))

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -82,7 +82,9 @@ module Game =
             | CardInformation (_, Matches _) -> true
             | CardInformation (_, DoesNotMatch _) -> false
 
-        let recipientIsSelf = GameState.activePlayer >> ((=) (Some recipient))
+        let recipientIsSelf history = GameState.activePlayer history = Some recipient
+
+        let recipientIsNotInGame = GameState.players >> List.contains recipient >> not
 
         let noMatchingCards history =
             (determineInfo history |> List.forall (not << isMatch)) && not (recipientIsSelf history)
@@ -91,6 +93,7 @@ module Game =
             [
                 NoMatchingCards, noMatchingCards
                 InvalidRecipient, recipientIsSelf
+                InvalidRecipient, recipientIsNotInGame
             ]
 
         let createEvents () =

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -66,7 +66,7 @@ module Game =
 
         performAction rules createEvents CannotStartGame history
 
-    let giveInformation _ cardTrait history =
+    let giveInformation recipient cardTrait history =
         let rules = []
 
         let createEvents () =
@@ -78,6 +78,7 @@ module Game =
             |> Seq.map StartTurn
             |> Seq.toList
             |> List.append (GameState.hands history
+                |> List.filter (fun hand -> hand.player = recipient)
                 |> List.collect (fun hand -> hand.cards)
                 |> List.map (function
                     | { instanceKey = key; identity = Card (suit, _) } when suit = cardTrait ->

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -66,7 +66,9 @@ module Game =
             let players = GameState.players history
             let cardsDealt = GameAction.dealInitialHands drawDeck players
             let firstPlayer = List.head players
-            (drawDeck |> List.map CardAddedToDrawDeck)
+
+            (List.replicate GameRules.clockTokensAvailable ClockTokenAdded)
+            @ (drawDeck |> List.map CardAddedToDrawDeck)
             @ (cardsDealt |> List.map CardDealtToPlayer)
             @ [StartTurn firstPlayer]
 
@@ -92,6 +94,7 @@ module Game =
 
         let rules =
             [
+                NoClockTokensAvailable, GameState.clockTokens >> (=) 0
                 NoMatchingCards, noMatchingCards
                 InvalidRecipient, recipientIsSelf
                 InvalidRecipient, recipientIsNotInGame
@@ -106,5 +109,6 @@ module Game =
             |> Seq.map StartTurn
             |> Seq.toList
             |> List.append (determineInfo history |> List.map InformationGiven)
+            |> List.append (ClockTokenSpent |> List.singleton)
 
         performAction rules createEvents CannotGiveInformation history

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -66,7 +66,7 @@ module Game =
 
         performAction rules createEvents CannotStartGame history
 
-    let giveInformation _ _ history =
+    let giveInformation _ cardTrait history =
         let rules = []
 
         let createEvents () =
@@ -77,5 +77,12 @@ module Game =
             |> Seq.take 1
             |> Seq.map StartTurn
             |> Seq.toList
+            |> List.append (GameState.hands history
+                |> List.collect (fun hand -> hand.cards)
+                |> List.map (function
+                    | { instanceKey = key; identity = Card (suit, _) } when suit = cardTrait ->
+                        InformationGiven (key, Matches cardTrait)
+                    | { instanceKey = key } ->
+                        InformationGiven (key, DoesNotMatch cardTrait)))
 
         performAction rules createEvents CannotStartGame history

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -74,18 +74,6 @@ module Game =
 
         performAction rules createEvents CannotStartGame history
 
-    let pass history =
-        let rules = []
-
-        let createEvents () =
-            GameAction.nextPlayer
-                (GameState.players history)
-                (GameState.activePlayer history |> Option.get)
-                |> StartTurn
-                |> List.singleton
-
-        performAction rules createEvents CannotGiveInformation history
-
     let giveInformation recipient cardTrait history =
         let determineInfo =
             GameState.hands

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -65,3 +65,10 @@ module Game =
             @ [StartTurn firstPlayer]
 
         performAction rules createEvents CannotStartGame history
+
+    let giveInformation _ _ =
+        let rules = []
+
+        let createEvents () = []
+
+        performAction rules createEvents CannotStartGame

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -101,14 +101,11 @@ module Game =
             ]
 
         let createEvents () =
-            Seq.initInfinite (fun _ -> GameState.players history)
-            |> Seq.collect id
-            |> Seq.skipWhile (Some >> (<>) (GameState.activePlayer history))
-            |> Seq.skip 1
-            |> Seq.take 1
-            |> Seq.map StartTurn
-            |> Seq.toList
-            |> List.append (determineInfo history |> List.map InformationGiven)
-            |> List.append (ClockTokenSpent |> List.singleton)
+            (GameAction.nextPlayer
+                (GameState.players history)
+                (GameState.activePlayer history |> Option.get)
+                |> StartTurn)
+            :: ClockTokenSpent
+            :: (determineInfo history |> List.map InformationGiven)
 
         performAction rules createEvents CannotGiveInformation history

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -9,6 +9,9 @@ type CannotStartGameReason =
     | WaitingForMinimumPlayers
     | GameAlreadyStarted
 
+type CannotTakeTurnReason =
+    | GameNotStarted
+
 type CannotGiveInformationReason =
     | NoClockTokensAvailable
     | NoMatchingCards
@@ -17,6 +20,7 @@ type CannotGiveInformationReason =
 type CannotPerformAction =
     | CannotAddPlayer of CannotAddPlayerReason list
     | CannotStartGame of CannotStartGameReason list
+    | CannotTakeTurn of CannotTakeTurnReason list
     | CannotGiveInformation of CannotGiveInformationReason list
 
 module Game =
@@ -108,4 +112,6 @@ module Game =
             :: ClockTokenSpent
             :: (determineInfo history |> List.map InformationGiven)
 
-        performAction rules createEvents CannotGiveInformation history
+        if GameState.activePlayer history = None
+        then Error (CannotTakeTurn [GameNotStarted])
+        else performAction rules createEvents CannotGiveInformation history

--- a/HanabiGuru.Engine/Game.fs
+++ b/HanabiGuru.Engine/Game.fs
@@ -66,11 +66,16 @@ module Game =
 
         performAction rules createEvents CannotStartGame history
 
-    let giveInformation _ _ =
+    let giveInformation _ _ history =
         let rules = []
 
         let createEvents () =
-            [Blue; Green; Red; Yellow; White]
-            |> List.map (fun suit -> InformationGiven (Card (suit, Rank 5)))
+            Seq.initInfinite (fun _ -> GameState.players history)
+            |> Seq.collect Set.toSeq
+            |> Seq.skipWhile (Some >> (<>) (GameState.activePlayer history))
+            |> Seq.skip 1
+            |> Seq.take 1
+            |> Seq.map StartTurn
+            |> Seq.toList
 
-        performAction rules createEvents CannotStartGame
+        performAction rules createEvents CannotStartGame history

--- a/HanabiGuru.Engine/GameAction.fs
+++ b/HanabiGuru.Engine/GameAction.fs
@@ -10,3 +10,10 @@ let dealInitialHands drawDeck players =
         |> List.sortBy (ignore >> Random.double)
         |> List.take (playerCount * handSize)
         |> List.map (fun card -> CardInstance.create (CardInstance.nextInstanceKey ()) card))
+
+let cardMatch cardTrait { instanceKey = key; identity = Card (suit, rank) } =
+    let matchType =
+        if SuitTrait suit = cardTrait || RankTrait rank = cardTrait
+        then Matches
+        else DoesNotMatch
+    CardInformation (key, matchType cardTrait)

--- a/HanabiGuru.Engine/GameAction.fs
+++ b/HanabiGuru.Engine/GameAction.fs
@@ -7,23 +7,7 @@ let dealInitialHands drawDeck players =
     |> Set.toList
     |> List.replicate handSize
     |> List.collect id
-    |> List.zip (drawDeck |> List.sortBy (ignore >> Random.double) |> List.take (playerCount * handSize))
-
-    (*
-let advanceTurn history =
-    let getPlayerJoined = function
-        | PlayerJoined player -> Some player
-        | _ -> None
-
-    let rules = [ GameNotStarted, not << EventHistory.exists isCardDealtToPlayer ]
-
-    let createEvents () =
-        Seq.initInfinite (fun _ -> EventHistory.choose getPlayerJoined history |> List.sort)
-        |> Seq.collect id
-        |> Seq.skip (EventHistory.countOf isNextTurn history)
-        |> Seq.take 1
-        |> Seq.map StartTurn
-        |> List.ofSeq
-
-    performAction rules createEvents CannotAdvanceTurn history
-    *)
+    |> List.zip (drawDeck
+        |> List.sortBy (ignore >> Random.double)
+        |> List.take (playerCount * handSize)
+        |> List.map (fun card -> CardInstance.create (CardInstance.nextInstanceKey ()) card))

--- a/HanabiGuru.Engine/GameAction.fs
+++ b/HanabiGuru.Engine/GameAction.fs
@@ -1,10 +1,9 @@
 ﻿module HanabiGuru.Engine.GameAction
 
 let dealInitialHands drawDeck players =
-    let playerCount = Set.count players
+    let playerCount = List.length players
     let handSize = if playerCount <= 3 then 5 else 4
     players
-    |> Set.toList
     |> List.replicate handSize
     |> List.collect id
     |> List.zip (drawDeck

--- a/HanabiGuru.Engine/GameAction.fs
+++ b/HanabiGuru.Engine/GameAction.fs
@@ -11,6 +11,13 @@ let dealInitialHands drawDeck players =
         |> List.take (playerCount * handSize)
         |> List.map (fun card -> CardInstance.create (CardInstance.nextInstanceKey ()) card))
 
+let nextPlayer players activePlayer =
+    Seq.initInfinite (fun _ -> players)
+    |> Seq.collect id
+    |> Seq.skipWhile ((<>) activePlayer)
+    |> Seq.skip 1
+    |> Seq.head
+
 let cardMatch cardTrait { instanceKey = key; identity = Card (suit, rank) } =
     let matchType =
         if SuitTrait suit = cardTrait || RankTrait rank = cardTrait

--- a/HanabiGuru.Engine/GameEvent.fs
+++ b/HanabiGuru.Engine/GameEvent.fs
@@ -5,9 +5,9 @@ type GameEvent =
     | FuseTokenAdded
     | ClockTokenAdded
     | CardAddedToDrawDeck of Card
-    | CardDealtToPlayer of Card * PlayerIdentity
+    | CardDealtToPlayer of CardInstance * PlayerIdentity
     | StartTurn of PlayerIdentity
-    | InformationGiven of Card
+    | InformationGiven of CardInstanceKey * CardTraitMatch
 
 module GameEvent =
     
@@ -24,9 +24,9 @@ module GameEvent =
             PlayerEvent.CardAddedToDrawDeck card |> Some
         | CardDealtToPlayer (card, otherPlayer) when otherPlayer <> player ->
             CardDealtToOtherPlayer (card, otherPlayer) |> Some
-        | CardDealtToPlayer _ ->
-            CardDealtToSelf |> Some
+        | CardDealtToPlayer ({ instanceKey = cardKey }, _) ->
+            CardDealtToSelf cardKey |> Some
         | StartTurn _ ->
             None
-        | InformationGiven card ->
-            InformationReceived card |> Some
+        | InformationGiven (cardKey, traitMatch) ->
+            InformationReceived (cardKey, traitMatch) |> Some

--- a/HanabiGuru.Engine/GameEvent.fs
+++ b/HanabiGuru.Engine/GameEvent.fs
@@ -7,7 +7,7 @@ type GameEvent =
     | CardAddedToDrawDeck of Card
     | CardDealtToPlayer of CardInstance * PlayerIdentity
     | StartTurn of PlayerIdentity
-    | InformationGiven of CardInstanceKey * CardTraitMatch
+    | InformationGiven of CardInformation
 
 module GameEvent =
     
@@ -28,5 +28,5 @@ module GameEvent =
             CardDealtToSelf cardKey |> Some
         | StartTurn _ ->
             None
-        | InformationGiven (cardKey, traitMatch) ->
+        | InformationGiven (CardInformation (cardKey, traitMatch)) ->
             InformationReceived (cardKey, traitMatch) |> Some

--- a/HanabiGuru.Engine/GameEvent.fs
+++ b/HanabiGuru.Engine/GameEvent.fs
@@ -8,6 +8,7 @@ type GameEvent =
     | CardDealtToPlayer of CardInstance * PlayerIdentity
     | StartTurn of PlayerIdentity
     | InformationGiven of CardInformation
+    | ClockTokenSpent
 
 module GameEvent =
     
@@ -30,3 +31,5 @@ module GameEvent =
             None
         | InformationGiven (CardInformation (cardKey, traitMatch)) ->
             InformationReceived (cardKey, traitMatch) |> Some
+        | ClockTokenSpent ->
+            PlayerEvent.ClockTokenSpent |> Some

--- a/HanabiGuru.Engine/GameEvent.fs
+++ b/HanabiGuru.Engine/GameEvent.fs
@@ -7,6 +7,7 @@ type GameEvent =
     | CardAddedToDrawDeck of Card
     | CardDealtToPlayer of Card * PlayerIdentity
     | StartTurn of PlayerIdentity
+    | InformationGiven of Card
 
 module GameEvent =
     
@@ -27,3 +28,5 @@ module GameEvent =
             CardDealtToSelf |> Some
         | StartTurn _ ->
             None
+        | InformationGiven card ->
+            InformationReceived card |> Some

--- a/HanabiGuru.Engine/GameState.fs
+++ b/HanabiGuru.Engine/GameState.fs
@@ -4,7 +4,6 @@ let players =
     EventHistory.choose (function 
         | PlayerJoined player -> Some player 
         | _ -> None) 
-    >> set 
 
 let fuseTokens _ = GameRules.fuseTokensAvailable
 

--- a/HanabiGuru.Engine/GameState.fs
+++ b/HanabiGuru.Engine/GameState.fs
@@ -7,7 +7,10 @@ let players =
 
 let fuseTokens _ = GameRules.fuseTokensAvailable
 
-let clockTokens _ = GameRules.clockTokensAvailable
+let clockTokens = EventHistory.sumBy (function
+    | ClockTokenAdded -> 1
+    | ClockTokenSpent -> -1
+    | _ -> 0)
 
 let drawDeck game =
     let cardsAddedToDrawDeck = 

--- a/HanabiGuru.Engine/GameState.fs
+++ b/HanabiGuru.Engine/GameState.fs
@@ -19,7 +19,7 @@ let drawDeck game =
     let cardsDealt = 
         game
         |> EventHistory.choose (function
-            | CardDealtToPlayer (card, _) -> Some card
+            | CardDealtToPlayer ({ identity = card }, _) -> Some card
             | _ -> None)
     List.removeEach cardsDealt cardsAddedToDrawDeck
 

--- a/HanabiGuru.Engine/Pair.fs
+++ b/HanabiGuru.Engine/Pair.fs
@@ -1,5 +1,7 @@
 ﻿module Pair
 
+let map f (fst, snd) = (f fst, f snd)
+
 let mapFst f (fst, snd) = (f fst, snd)
 
 let mapSnd f (fst, snd) = (fst, f snd)

--- a/HanabiGuru.Engine/Pair.fs
+++ b/HanabiGuru.Engine/Pair.fs
@@ -1,7 +1,5 @@
 ﻿module Pair
 
-let map f (fst, snd) = (f fst, f snd)
-
 let mapFst f (fst, snd) = (f fst, snd)
 
 let mapSnd f (fst, snd) = (fst, f snd)

--- a/HanabiGuru.Engine/Player.fs
+++ b/HanabiGuru.Engine/Player.fs
@@ -5,7 +5,7 @@ type PlayerIdentity = Name of string
 type PlayerHand =
     {
         player : PlayerIdentity
-        cards : Card list
+        cards : CardInstance list
     }
 
 module PlayerIdentity =

--- a/HanabiGuru.Engine/PlayerEvent.fs
+++ b/HanabiGuru.Engine/PlayerEvent.fs
@@ -6,6 +6,6 @@ type PlayerEvent =
     | FuseTokenAdded
     | ClockTokenAdded
     | CardAddedToDrawDeck of Card
-    | CardDealtToSelf
-    | CardDealtToOtherPlayer of Card * PlayerIdentity
-    | InformationReceived of Card
+    | CardDealtToSelf of CardInstanceKey
+    | CardDealtToOtherPlayer of CardInstance * PlayerIdentity
+    | InformationReceived of CardInstanceKey * CardTraitMatch

--- a/HanabiGuru.Engine/PlayerEvent.fs
+++ b/HanabiGuru.Engine/PlayerEvent.fs
@@ -8,3 +8,4 @@ type PlayerEvent =
     | CardAddedToDrawDeck of Card
     | CardDealtToSelf
     | CardDealtToOtherPlayer of Card * PlayerIdentity
+    | InformationReceived of Card

--- a/HanabiGuru.Engine/PlayerEvent.fs
+++ b/HanabiGuru.Engine/PlayerEvent.fs
@@ -9,3 +9,4 @@ type PlayerEvent =
     | CardDealtToSelf of CardInstanceKey
     | CardDealtToOtherPlayer of CardInstance * PlayerIdentity
     | InformationReceived of CardInstanceKey * CardTraitMatch
+    | ClockTokenSpent

--- a/HanabiGuru.Engine/PlayerView.fs
+++ b/HanabiGuru.Engine/PlayerView.fs
@@ -48,6 +48,9 @@ module CardIdentity =
             |> List.removeEach (List.choose (function
                 | CardDealtToOtherPlayer (card, _) -> Some card
                 | _ -> None) view)
+            |> List.removeEach (List.choose (function
+                | InformationReceived card -> Some card
+                | _ -> None) view)
             |> List.countBy id
         let unrevealedCount = List.sumBy snd unrevealedCards
 

--- a/HanabiGuru.Engine/PlayerView.fs
+++ b/HanabiGuru.Engine/PlayerView.fs
@@ -53,11 +53,13 @@ module CardIdentity =
             |> List.removeEach (List.choose (function
                 | CardDealtToOtherPlayer ({ identity = card }, _) -> Some card
                 | _ -> None) view)
-            |> List.filter (fun (Card (suit, _)) ->
+            |> List.filter (fun (Card (suit, rank)) ->
                 information
                 |> List.exists (function
-                    | Matches matchingSuit -> matchingSuit <> suit
-                    | DoesNotMatch notMatchingSuit -> notMatchingSuit = suit)
+                    | Matches (SuitTrait matchingSuit) -> matchingSuit <> suit
+                    | Matches (RankTrait matchingRank) -> matchingRank <> rank
+                    | DoesNotMatch (SuitTrait notMatchingSuit) -> notMatchingSuit = suit
+                    | DoesNotMatch (RankTrait notMatchingRank) -> notMatchingRank = rank)
                 |> not)
             |> List.countBy id
         let candidatesCount = List.sumBy snd candidates

--- a/HanabiGuru.Engine/PlayerView.fs
+++ b/HanabiGuru.Engine/PlayerView.fs
@@ -34,7 +34,10 @@ let otherHand player view =
 
 let fuseTokens _ = GameRules.fuseTokensAvailable
 
-let clockTokens _ = GameRules.clockTokensAvailable
+let clockTokens = List.sumBy (function
+    | ClockTokenAdded -> 1
+    | ClockTokenSpent -> -1
+    | _ -> 0)
 
 module CardIdentity =
     

--- a/HanabiGuru.Engine/PlayerView.fs
+++ b/HanabiGuru.Engine/PlayerView.fs
@@ -25,13 +25,12 @@ let hand =
         | CardDealtToSelf cardKey -> ConcealedCard cardKey |> Some
         | _ -> None)
 
-let otherHands =
-    List.choose (function
-        | CardDealtToOtherPlayer (card, otherPlayer) -> Some (card, otherPlayer)
+let otherHand player view =
+    view
+    |> List.choose (function
+        | CardDealtToOtherPlayer (card, otherPlayer) when otherPlayer = player -> Some card
         | _ -> None)
-    >> List.groupBy snd
-    >> List.map (Pair.mapSnd (List.map fst))
-    >> List.map (fun (player, cards) -> PlayerHand.create player cards)
+    |> PlayerHand.create player
 
 let fuseTokens _ = GameRules.fuseTokensAvailable
 


### PR DESCRIPTION
Players can use their turn to give information to another player about the cards they are holding in their hand, at the cost of a clock token.

This also allows players to eliminate many possible identities for the cards they are holding in their own hand, given the information they have received. Combining this with the information they already have based on the identities of the cards they can see in the hands of the other players, they are able to make some strong deductions.